### PR TITLE
Fix People Analytics for Android

### DIFF
--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -129,6 +129,7 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     @ReactMethod
     public void identify(final String user_id) {
         mixpanel.identify(user_id);
+        mixpanel.getPeople().identify(user_id);
     }
 
     @ReactMethod


### PR DESCRIPTION
According to quote from https://mixpanel.com/help/reference/android
> Before you send profile updates, you must call getPeople().identify. The library uses a separate ID for People records, and you must set this value to send updates.