### PR TITLE
Modify 'set' to more closely follow 'mixpanel.people set'

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE(RNMixpanel)
 RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken) {
     [Mixpanel sharedInstanceWithToken:apiToken];
     mixpanel = [Mixpanel sharedInstance];
-    // React Native runs too late to listen for applicationDidBecomeActive, 
+    // React Native runs too late to listen for applicationDidBecomeActive,
     // so we expose the private method and call it explicitly here,
     // to ensure that important things like initializing the flush timer and
     // checking for pending surveys and notifications.
@@ -72,8 +72,8 @@ RCT_EXPORT_METHOD(registerSuperPropertiesOnce:(NSDictionary *)properties) {
 }
 
 // Set People Data
-RCT_EXPORT_METHOD(set:(NSString *)key value:(NSString *)value) {
-    [mixpanel.people set:@{key: value}];
+RCT_EXPORT_METHOD(set:(NSDictionary *)properties) {
+    [mixpanel.people set:properties];
 }
 
 // track Revenue


### PR DESCRIPTION
The Mixpanel SKD accepts an NSDictionary of properties [(link)](https://mixpanel.com/site_media/doctyl/uploads/iPhone-spec/Classes/MixpanelPeople/index.html#//apple_ref/occ/instm/MixpanelPeople/set:), so I've modified the set function to accept the same.