### PR TITLE
add mixpanel.people setOnce method

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Mixpanel.identify(UNIQUE_ID)
 //Set People properties
 Mixpanel.set("$email", "elvis@email.com");
 
+//Set People Properties Once
+Mixpanel.setOnce({"$email": "elvis@email.com", "Created": new Date().toISOString()});
+
 // Timing Events
 // Sets the start time for an action, for example uploading an image
 Mixpanel.timeEvent("Image Upload");
@@ -86,7 +89,7 @@ Mixpanel.track("Image Upload");
 Mixpanel.registerSuperProperties({"Account type": "Free", "User Type": "Vendor"});
 
 // Register super properties Once
-Mixpanel.registerSuperProperties({"Gender": "Female"});
+Mixpanel.registerSuperPropertiesOnce({"Gender": "Female"});
 
 // track Revenue
 Mixpanel.trackCharge(399);

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -76,6 +76,11 @@ RCT_EXPORT_METHOD(set:(NSDictionary *)properties) {
     [mixpanel.people set:properties];
 }
 
+// Set People Data Once
+RCT_EXPORT_METHOD(setOnce:(NSDictionary *)properties) {
+    [mixpanel.people setOnce: properties];
+}
+
 // track Revenue
 RCT_EXPORT_METHOD(trackCharge:(nonnull NSNumber *)charge) {
     [mixpanel.people trackCharge:charge];


### PR DESCRIPTION
Added a `mixpanel.people setOnce` method and updated README.  `setOnce` will only set the user property value if it does not already exist.