### PR TITLE
Props -> properties typo

### DIFF
--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -110,10 +110,10 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void trackWithProperties(final String name, final ReadableMap props) {
+    public void trackWithProperties(final String name, final ReadableMap properties) {
         JSONObject obj = null;
         try {
-            obj = RNMixpanelModule.reactToJSON(props);
+            obj = RNMixpanelModule.reactToJSON(properties);
         } catch (JSONException e) {
             e.printStackTrace();
         }
@@ -165,7 +165,7 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     public void set(final ReadableMap properties) {
         JSONObject obj = null;
         try {
-            obj = RNMixpanelModule.reactToJSON(props);
+            obj = RNMixpanelModule.reactToJSON(properties);
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Typo which caused compile-error in Android, changed occurrences of props to properties for clarity.