### PR TITLE
Bring back React as a dependency of the cocoapod

### DIFF
--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "7.0"
   s.dependency 'Mixpanel'
+  s.dependency 'React'
 end


### PR DESCRIPTION
The pod is unable to reference RN's headers when compiled as a framework without RN as a dependency.

Fixes errors like:

```
RNMixpanel.h:9:9: 'RCTBridgeModule.h' file not found
```
