### PR TITLE
add getSuperPropertyMethod

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -37,6 +37,18 @@ RCT_EXPORT_METHOD(getDistinctId:(RCTResponseSenderBlock)callback) {
     callback(@[mixpanel.distinctId]);
 }
 
+// get superProp
+RCT_EXPORT_METHOD(getSuperProperty: (NSString *)prop callback:(RCTResponseSenderBlock)callback) {
+    NSDictionary *currSuperProps = [mixpanel currentSuperProperties];
+    
+    if ([currSuperProps objectForKey:prop]) {
+        NSString *superProp = currSuperProps[prop];
+        callback(@[superProp]);
+    } else {
+        callback(@[[NSNull null]]);
+    }
+}
+
 // track
 RCT_EXPORT_METHOD(track:(NSString *)event) {
     [mixpanel track:event];


### PR DESCRIPTION
Fixes #58 

this method accepts a superProperty and a callback.
The callback will be called with the value of the superProperty. If the super property doesn't exist, it is called with null.

eg:

``` js
Mixpanel.getSuperProperty('name', (val) => {
    if(val) {
        console.log(val)
    }
})
```
