### PR TITLE
Remove duplicate function on iOS and getDistinctId on Android

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -129,11 +129,6 @@ RCT_EXPORT_METHOD(increment:(NSString *)property count:(nonnull NSNumber *)count
     [mixpanel.people increment:property by:count];
 }
 
-// addPushDeviceToken
-RCT_EXPORT_METHOD(addPushDeviceToken:(NSString *)pushDeviceToken) {
-  [mixpanel.people addPushDeviceToken:pushDeviceToken];
-}
-
 // reset
 RCT_EXPORT_METHOD(reset) {
     [mixpanel reset];

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -259,8 +259,8 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
         }
     }
 
-    @ReactMethod
-    public void getDistinctId(Callback callback) {
-        callback.invoke(mixpanel.getDistinctId());
-    }
+//     @ReactMethod
+//     public void getDistinctId(Callback callback) {
+//         callback.invoke(mixpanel.getDistinctId());
+//     }
 }


### PR DESCRIPTION
Removes the second call to addPushDeviceToken on iOS and comments out getDistinctId on Android (for now) causing compile issues due to Callback not being declared.