### PR TITLE
Assign new UUID on iOS when calling reset()

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -40,7 +40,7 @@ RCT_EXPORT_METHOD(getDistinctId:(RCTResponseSenderBlock)callback) {
 // get superProp
 RCT_EXPORT_METHOD(getSuperProperty: (NSString *)prop callback:(RCTResponseSenderBlock)callback) {
     NSDictionary *currSuperProps = [mixpanel currentSuperProperties];
-    
+
     if ([currSuperProps objectForKey:prop]) {
         NSString *superProp = currSuperProps[prop];
         callback(@[superProp]);
@@ -132,6 +132,8 @@ RCT_EXPORT_METHOD(increment:(NSString *)property count:(nonnull NSNumber *)count
 // reset
 RCT_EXPORT_METHOD(reset) {
     [mixpanel reset];
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    [mixpanel identify:uuid];
 }
 
 @end


### PR DESCRIPTION
See https://blog.mixpanel.com/2015/09/21/community-tip-maintaining-user-identity/

"...When you call the reset method it will reset super properties, but the Distinct Id will always be associated with that device due to the way IFA/IFV is managed. What you’ll need to do is generate a new UUID and pass this as an argument to the identify method in order to reset the Distinct Id to be anonymous for the next user."