### PR TITLE
Push notification token docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ Mixpanel.trackChargeWithProperties(399, {"product": "ACME Wearable tech"});
 Mixpanel.increment("Login Count", 1);
 
 // send push notifications token to Mixpanel
-Mixpanel.initPushHandling("token_from_apple_or_google");
+// Android
+Mixpanel.initPushHandling("GCM/FCM sender ID");
+// iOS
+Mixpanel.addPushDeviceToken("APNS push token")
 
 // Mixpanel reset method
 Mixpanel.reset();

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Mixpanel.increment("Login Count", 1);
 
 // send push notifications token to Mixpanel
 // Android
-Mixpanel.initPushHandling("GCM/FCM sender ID");
+Mixpanel.setPushRegistrationId("GCM/FCM push token");
 // iOS
 Mixpanel.addPushDeviceToken("APNS push token")
 


### PR DESCRIPTION
In order to get push notifications properly working I had to make different calls depending on Apple/Android. These changes are now inline with official Mixpanel documentation.