### PR TITLE
Easier handling of push-tokens

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -104,11 +104,6 @@ RCT_EXPORT_METHOD(setOnce:(NSDictionary *)properties) {
     [mixpanel.people setOnce: properties];
 }
 
-// Add Person's Push Token (iOS-only)
-RCT_EXPORT_METHOD(addPushDeviceToken:(NSData *)deviceToken) {
-    [mixpanel.people addPushDeviceToken:deviceToken];
-}
-
 // Remove Person's Push Token (iOS-only)
 RCT_EXPORT_METHOD(removePushDeviceToken:(NSData *)deviceToken) {
     [mixpanel.people removePushDeviceToken:deviceToken];
@@ -134,20 +129,20 @@ RCT_EXPORT_METHOD(increment:(NSString *)property count:(nonnull NSNumber *)count
     [mixpanel.people increment:property by:count];
 }
 
- // addPushDeviceToken
- RCT_EXPORT_METHOD(addPushDeviceToken:(NSString *)pushDeviceToken) {
-     NSMutableData *deviceToken = [[NSMutableData alloc] init];
-     unsigned char whole_byte;
-     char byte_chars[3] = {'\0','\0','\0'};
-     int i;
-     for (i=0; i < [pushDeviceToken length]/2; i++) {
-         byte_chars[0] = [pushDeviceToken characterAtIndex:i*2];
-         byte_chars[1] = [pushDeviceToken characterAtIndex:i*2+1];
-         whole_byte = strtol(byte_chars, NULL, 16);
-         [deviceToken appendBytes:&whole_byte length:1];
-     }
-     [mixpanel.people addPushDeviceToken:deviceToken];
- }
+// Add Person's Push Token (iOS-only)
+RCT_EXPORT_METHOD(addPushDeviceToken:(NSString *)pushDeviceToken) {
+    NSMutableData *deviceToken = [[NSMutableData alloc] init];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [pushDeviceToken length]/2; i++) {
+        byte_chars[0] = [pushDeviceToken characterAtIndex:i*2];
+        byte_chars[1] = [pushDeviceToken characterAtIndex:i*2+1];
+        whole_byte = strtol(byte_chars, NULL, 16);
+        [deviceToken appendBytes:&whole_byte length:1];
+    }
+    [mixpanel.people addPushDeviceToken:deviceToken];
+}
 
 // reset
 RCT_EXPORT_METHOD(reset) {

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -102,6 +102,21 @@ RCT_EXPORT_METHOD(increment:(NSString *)property count:(nonnull NSNumber *)count
   [mixpanel.people increment:property by:count];
 }
 
+ // addPushDeviceToken
+ RCT_EXPORT_METHOD(addPushDeviceToken:(NSString *)pushDeviceToken) {
+     NSMutableData *deviceToken = [[NSMutableData alloc] init];
+     unsigned char whole_byte;
+     char byte_chars[3] = {'\0','\0','\0'};
+     int i;
+     for (i=0; i < [pushDeviceToken length]/2; i++) {
+         byte_chars[0] = [pushDeviceToken characterAtIndex:i*2];
+         byte_chars[1] = [pushDeviceToken characterAtIndex:i*2+1];
+         whole_byte = strtol(byte_chars, NULL, 16);
+         [deviceToken appendBytes:&whole_byte length:1];
+     }
+     [mixpanel.people addPushDeviceToken:deviceToken];
+ }
+
 // reset
 RCT_EXPORT_METHOD(reset) {
     [mixpanel reset];

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -239,11 +239,6 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
         mixpanel.flush();
     }
 
-    @ReactMethod
-    public void initPushHandling(final String gcmSenderId) {
-        mixpanel.getPeople().initPushHandling(gcmSenderId);
-    }
-
     @Override
     public void onHostResume() {
         // Actvity `onResume`

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -206,6 +206,11 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
         mixpanel.flush();
     }
 
+    @ReactMethod
+    public void initPushHandling(final String gcmSenderId) {
+        mixpanel.getPeople().initPushHandling(gcmSenderId);
+    }
+
     @Override
     public void onHostResume() {
         // Actvity `onResume`


### PR DESCRIPTION
At least I always get my device tokens as strings and I found it more convenient to pass them as as strings and then convert to proper device tokens before adding to Mixpanel.!