### PR TITLE
fix android compile on react-native 0.47

### DIFF
--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanel.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanel.java
@@ -25,7 +25,6 @@ public class RNMixpanel implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[createJSModules is now not required on Android from RN 0.47](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) and breaks android compile, removing override fixes this