### PR TITLE
Update on #99: call our addPushDeviceToken from initPushHandling

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(registerSuperPropertiesOnce:(NSDictionary *)properties) {
 
 // Init push notification
 RCT_EXPORT_METHOD(initPushHandling:(NSString *) token) {
-     [mixpanel.people addPushDeviceToken:token];
+     [self addPushDeviceToken:token];
 }
 
 // Set People Data


### PR DESCRIPTION
Hey @davodesign84 ,

Thanks for the awesome library!

As I got crashes caused by initPushHandling not calling the custom addPushDeviceToken added in #99 (performing conversions from NSString to NSData), I'm trying to make a fix that's working for me. Please, let me know if that improves the stability of your library.

Also, if you could release a new version 0.0.16 on npmjs and also make tags/releases so that it would be clear, which codebase snapshot the npm version corresponds to, it would be very helpful to triage the bugs in the future.

Cheers,
Vitaly