### PR TITLE
Remove problematic Header Search Path for Xcode 9 support

### DIFF
--- a/RNMixpanel.xcodeproj/project.pbxproj
+++ b/RNMixpanel.xcodeproj/project.pbxproj
@@ -311,7 +311,6 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/**",
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
@@ -326,7 +325,6 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/**",
 					"$(SRCROOT)/../../React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
@@ -346,6 +344,7 @@
 				5EAEEA481F0555B100C6FED8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		FDC64AEB1BF1690D0044C1B4 /* Build configuration list for PBXProject "RNMixpanel" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Remove '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include' Header Search Path' (Xcode 9 support)