### PR TITLE
Make sharedInstanceWithToken available at ios AppDelegate.m

### DIFF
--- a/RNMixpanel/RNMixpanel.h
+++ b/RNMixpanel/RNMixpanel.h
@@ -10,4 +10,6 @@
 
 @interface RNMixpanel : NSObject<RCTBridgeModule>
 
++ (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions;
+
 @end

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -18,6 +18,11 @@
 
 Mixpanel *mixpanel = nil;
 
+// Called by AppDelegate.m
++ (void)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions {
+    mixpanel = [Mixpanel sharedInstanceWithToken:apiToken launchOptions:launchOptions];
+}
+
 // Expose this module to the React Native bridge
 RCT_EXPORT_MODULE(RNMixpanel)
 


### PR DESCRIPTION
`launchOptions`, the second parameter of `sharedInstanceWithToken `, is essential to track open rate of Mixpanel push notification.
