### PR TITLE
Update mixpanel dependency for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile "com.mixpanel.android:mixpanel-android:5.1.4"
+    compile "com.mixpanel.android:mixpanel-android:5.+"
 }


### PR DESCRIPTION
This demands the highest possible 5.x version available