### PR TITLE
Support using previously configured sharedInstance

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -26,6 +26,13 @@ Mixpanel *mixpanel = nil;
 // Expose this module to the React Native bridge
 RCT_EXPORT_MODULE(RNMixpanel)
 
+// sharedInstance
+RCT_EXPORT_METHOD(sharedInstance) {
+    // if [Mixpanel sharedInstanceWithToken / initWithToken ...] have been
+    // called from AppDelegate already.
+    mixpanel = [Mixpanel sharedInstance];
+}
+
 // sharedInstanceWithToken
 RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken) {
     mixpanel = [Mixpanel sharedInstanceWithToken:apiToken];


### PR DESCRIPTION
We needed to call `initWithToken` from AppDelegate in order to specify more configuration (`trackCrashes:NO` etc) and so this is to set the already existing `sharedInstance` in RNMixpanel. 