### PR TITLE
Disable IP address Geolocalizaiton for GDPR related issues on iOS

### DIFF
--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -95,6 +95,21 @@
 
 /*!
  @property
+ 
+ @abstract
+ Controls whether to automatically send the client IP Address as part of
+ event tracking. With an IP address, geo-location is possible down to neighborhoods
+ within a city, although the Mixpanel Dashboard will just show you city level location
+ specificity. For privacy reasons, you may be in a situation where you need to forego
+ effectively having access to such granular location information via the IP Address.
+ 
+ @discussion
+ Defaults to YES.
+ */
+@property (atomic) BOOL useIPAddressForGeoLocation;
+
+/*!
+ @property
 
  @abstract
  Control whether the library should flush data to Mixpanel when the app

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -77,7 +77,7 @@ RCT_EXPORT_METHOD(disableIpAddressGeolocalization:(NSString *)apiToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     [self getInstance:apiToken].useIPAddressForGeoLocation = NO;
-    resolve(nil);;
+    resolve(nil);
 }
 
 // track with properties

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -72,6 +72,14 @@ RCT_EXPORT_METHOD(track:(NSString *)event
     resolve(nil);
 }
 
+// disable ip address geolocalization
+RCT_EXPORT_METHOD(disableIpAddressGeolocalization:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self getInstance:apiToken].useIPAddressForGeoLocation = NO;
+    resolve(nil);;
+}
+
 // track with properties
 RCT_EXPORT_METHOD(trackWithProperties:(NSString *)event
                   properties:(NSDictionary *)properties

--- a/index.js
+++ b/index.js
@@ -246,6 +246,12 @@ export default {
     defaultInstance.flush()
   },
 
+  disableIpAddressGeolocalization() {
+      if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+      defaultInstance.disableIpAddressGeolocalization()
+  },
+
   createAlias(alias: string) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,11 @@ export class MixpanelInstance {
     return RNMixpanel.flush(this.apiToken)
   }
 
+  disableIpAddressGeolocalization(): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('disableIpAddressGeolocalization'))
+    return RNMixpanel.disableIpAddressGeolocalization(this.apiToken)
+  }
+
   alias(alias: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('createAlias'))
 


### PR DESCRIPTION
On iOS:
`if (Platform.OS === "ios") {
  Mixpanel.disableIpAddressGeolocalization();
}`

On Android you just need to add to the AndroidManifest file:  
` <meta-data android:name="com.mixpanel.android.MPConfig.UseIpAddressForGeolocation"
            android:value="false" />`