### PR TITLE
Pass deviceToken as string to `removePushDeviceToken`

### DIFF
--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -186,10 +186,22 @@ RCT_EXPORT_METHOD(setOnce:(NSDictionary *)properties
 }
 
 // Remove Person's Push Token (iOS-only)
-RCT_EXPORT_METHOD(removePushDeviceToken:(NSData *)deviceToken
+RCT_EXPORT_METHOD(removePushDeviceToken:(NSString *)pushDeviceToken
                   apiToken:(NSString *)apiToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
+
+    NSMutableData *deviceToken = [[NSMutableData alloc] init];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [pushDeviceToken length]/2; i++) {
+        byte_chars[0] = [pushDeviceToken characterAtIndex:i*2];
+        byte_chars[1] = [pushDeviceToken characterAtIndex:i*2+1];
+        whole_byte = strtol(byte_chars, NULL, 16);
+        [deviceToken appendBytes:&whole_byte length:1];
+    }
+
     [[self getInstance:apiToken].people removePushDeviceToken:deviceToken];
     resolve(nil);
 }

--- a/index.js
+++ b/index.js
@@ -148,10 +148,10 @@ export class MixpanelInstance {
     return RNMixpanel.union(name, properties, this.apiToken)
   }
 
-  removePushDeviceToken(deviceToken: Object): Promise<void> {
+  removePushDeviceToken(token: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('removePushDeviceToken'))
 
-    return RNMixpanel.removePushDeviceToken(deviceToken, this.apiToken)
+    return RNMixpanel.removePushDeviceToken(token, this.apiToken)
   }
 
   removeAllPushDeviceTokens(): Promise<void> {
@@ -306,10 +306,10 @@ export default {
     defaultInstance.setOnce(properties)
   },
 
-  removePushDeviceToken(deviceToken: Object) {
+  removePushDeviceToken(token: string) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
-    defaultInstance.removePushDeviceToken(deviceToken)
+    defaultInstance.removePushDeviceToken(token)
   },
 
   removeAllPushDeviceTokens() {


### PR DESCRIPTION
For the same reason as #99, I also think its convenient to pass devicetoken as string to `removePushDeviceToken`.