### PR TITLE
Replaced compile with implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.mixpanel.android:mixpanel-android:5.3.0"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.mixpanel.android:mixpanel-android:5.3.0"
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018