### PR TITLE
Add more parameters to initialize mixpanel instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ var Mixpanel = require('react-native-mixpanel');
 //Init Mixpanel SDK with your project token
 Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN);
 
+//Init Mixpanel SDK with your project token
+//launchOptions default value is nil
+//trackCrashes default value is true
+//automaticPushTracking default value is true
+//optOutTrackingByDefault default value is true
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN,launchOptions,trackCrashes,automaticPushTracking,optOutTrackingByDefault);
+
 //Send and event name with no properties
 Mixpanel.track("Event name");
 

--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -1,18 +1,46 @@
 #import <Foundation/Foundation.h>
-
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#else
+#import <Cocoa/Cocoa.h>
+#endif
+#import "MixpanelPeople.h"
+
+#if defined(MIXPANEL_WATCHOS)
+#define MIXPANEL_FLUSH_IMMEDIATELY 1
+#define MIXPANEL_NO_APP_LIFECYCLE_SUPPORT 1
+#endif
+
+#if (defined(MIXPANEL_WATCHOS) || defined(MIXPANEL_MACOS))
+#define MIXPANEL_NO_UIAPPLICATION_ACCESS 1
+#endif
+
+#if (defined(MIXPANEL_TVOS) || defined(MIXPANEL_WATCHOS) || defined(MIXPANEL_MACOS))
+#define MIXPANEL_NO_REACHABILITY_SUPPORT 1
+#define MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT 1
+#define MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT 1
+#define MIXPANEL_NO_CONNECT_INTEGRATION_SUPPORT 1
+#endif
 
 @class    MixpanelPeople;
 @protocol MixpanelDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
- @class
+ A string constant "mini" that respresent Mini Notification
+ */
+extern NSString *const MPNotificationTypeMini;
+/*!
+ A string constant "takeover" that respresent Takeover Notification
+ */
+extern NSString *const MPNotificationTypeTakeover;
+
+/*!
  Mixpanel API.
 
- @abstract
  The primary interface for integrating Mixpanel with your app.
 
- @discussion
  Use the Mixpanel class to set up your project and track events in Mixpanel
  Engagement. It now also includes a <code>people</code> property for accessing
  the Mixpanel People API.
@@ -25,7 +53,7 @@
  [mixpanel track:@"Button Clicked"];
 
  // Set properties on a user in Mixpanel People
- [mixpanel.people identify:@"CURRENT USER DISTINCT ID"];
+ [mixpanel identify:@"CURRENT USER DISTINCT ID"];
  [mixpanel.people set:@"Plan" to:@"Premium"];
  </pre>
 
@@ -38,138 +66,69 @@
 #pragma mark Properties
 
 /*!
- @property
-
- @abstract
  Accessor to the Mixpanel People API object.
 
- @discussion
  See the documentation for MixpanelDelegate below for more information.
  */
 @property (atomic, readonly, strong) MixpanelPeople *people;
 
 /*!
- @property
-
- @abstract
  The distinct ID of the current user.
 
- @discussion
- A distinct ID is a string that uniquely identifies one of your users.
- Typically, this is the user ID from your database. By default, we'll use a
- hash of the MAC address of the device. To change the current distinct ID,
- use the <code>identify:</code> method.
+ A distinct ID is a string that uniquely identifies one of your users. By default, 
+ we'll use the device's advertisingIdentifier UUIDString, if that is not available
+ we'll use the device's identifierForVendor UUIDString, and finally if that
+ is not available we will generate a new random UUIDString. To change the
+ current distinct ID, use the <code>identify:</code> method.
  */
 @property (atomic, readonly, copy) NSString *distinctId;
 
 /*!
- @property
-
- @abstract
- Current user's name in Mixpanel Streams.
+ The alias of the current user.
+ 
+ An alias is another string that uniquely identifies one of your users. Typically, 
+ this is the user ID from your database. By using an alias you can link pre- and
+ post-sign up activity as well as cross-platform activity under one distinct ID.
+ To set the alias use the <code>createAlias:forDistinctID:</code> method.
  */
-@property (atomic, copy) NSString *nameTag;
+@property (atomic, readonly, copy) NSString *alias;
 
 /*!
- @property
-
- @abstract
  The base URL used for Mixpanel API requests.
 
- @discussion
  Useful if you need to proxy Mixpanel requests. Defaults to
  https://api.mixpanel.com.
  */
-@property (atomic, copy) NSString *serverURL;
+@property (nonatomic, copy) NSString *serverURL;
 
 /*!
- @property
-
- @abstract
  Flush timer's interval.
 
- @discussion
  Setting a flush interval of 0 will turn off the flush timer.
  */
 @property (atomic) NSUInteger flushInterval;
 
 /*!
- @property
- 
- @abstract
- Controls whether to automatically send the client IP Address as part of
- event tracking. With an IP address, geo-location is possible down to neighborhoods
- within a city, although the Mixpanel Dashboard will just show you city level location
- specificity. For privacy reasons, you may be in a situation where you need to forego
- effectively having access to such granular location information via the IP Address.
- 
- @discussion
- Defaults to YES.
- */
-@property (atomic) BOOL useIPAddressForGeoLocation;
-
-/*!
- @property
-
- @abstract
  Control whether the library should flush data to Mixpanel when the app
  enters the background.
 
- @discussion
  Defaults to YES. Only affects apps targeted at iOS 4.0, when background
  task support was introduced, and later.
  */
 @property (atomic) BOOL flushOnBackground;
 
 /*!
- @property
-
- @abstract
  Controls whether to show spinning network activity indicator when flushing
  data to the Mixpanel servers.
 
- @discussion
  Defaults to YES.
  */
-@property (atomic) BOOL showNetworkActivityIndicator;
+@property (atomic) BOOL shouldManageNetworkActivityIndicator;
 
 /*!
- @property
-
- @abstract
- Controls whether to automatically check for surveys for the
- currently identified user when the application becomes active.
-
- @discussion
- Defaults to YES. Will fire a network request on
- <code>applicationDidBecomeActive</code> to retrieve a list of valid surveys
- for the currently identified user.
- */
-@property (atomic) BOOL checkForSurveysOnActive;
-
-/*!
- @property
-
- @abstract
- Controls whether to automatically show a survey for the
- currently identified user when the application becomes active.
-
- @discussion
- Defaults to YES. This will only show a survey if
- <code>checkForSurveysOnActive</code> is also set to YES, and the
- survey check retrieves at least 1 valid survey for the currently
- identified user.
- */
-@property (atomic) BOOL showSurveyOnActive;
-
-/*!
- @property
-
- @abstract
  Controls whether to automatically check for notifications for the
  currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES. Will fire a network request on
  <code>applicationDidBecomeActive</code> to retrieve a list of valid notifications
  for the currently identified user.
@@ -177,13 +136,9 @@
 @property (atomic) BOOL checkForNotificationsOnActive;
 
 /*!
- @property
-
- @abstract
  Controls whether to automatically check for A/B test variants for the
  currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES. Will fire a network request on
  <code>applicationDidBecomeActive</code> to retrieve a list of valid variants
  for the currently identified user.
@@ -191,64 +146,77 @@
 @property (atomic) BOOL checkForVariantsOnActive;
 
 /*!
- @property
-
- @abstract
  Controls whether to automatically check for and show in-app notifications
  for the currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES.
  */
 @property (atomic) BOOL showNotificationOnActive;
 
 /*!
- @property
+ Controls whether to automatically send the client IP Address as part of 
+ event tracking. With an IP address, geo-location is possible down to neighborhoods
+ within a city, although the Mixpanel Dashboard will just show you city level location
+ specificity. For privacy reasons, you may be in a situation where you need to forego
+ effectively having access to such granular location information via the IP Address.
+ 
+ Defaults to YES.
+ */
+@property (atomic) BOOL useIPAddressForGeoLocation;
 
- @abstract
+/*!
+ Controls whether to enable the visual test designer for A/B testing and codeless on mixpanel.com. 
+ You will be unable to edit A/B tests and codeless events with this disabled, however *previously*
+ created A/B tests and codeless events will still be delivered.
+ 
+ Defaults to YES.
+ */
+@property (atomic) BOOL enableVisualABTestAndCodeless;
+
+/*!
+ Controls whether to enable the run time debug logging at all levels. Note that the
+ Mixpanel SDK uses Apple System Logging to forward log messages to `STDERR`, this also
+ means that mixpanel logs are segmented by log level. Settings this to `YES` will enable 
+ Mixpanel logging at the following levels:
+ 
+   * Error - Something has failed 
+   * Warning - Something is amiss and might fail if not corrected
+   * Info - The lowest priority that is normally logged, purely informational in nature
+   * Debug - Information useful only to developers, and normally not logged.
+ 
+ 
+ Defaults to NO.
+ */
+@property (atomic) BOOL enableLogging;
+
+/*!
  Determines the time, in seconds, that a mini notification will remain on
  the screen before automatically hiding itself.
 
- @discussion
  Defaults to 6.0.
  */
 @property (atomic) CGFloat miniNotificationPresentationTime;
 
+#if !MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT
 /*!
- @property
+ The minimum session duration (ms) that is tracked in automatic events.
 
- @abstract
- If set, determines the background color of mini notifications.
-
- @discussion
- If this isn't set, we default to either the color of the UINavigationBar of the top
- UINavigationController that is showing when the notification is presented, the
- UINavigationBar default color for the app or the UITabBar default color.
- */
-@property (atomic) UIColor* miniNotificationBackgroundColor;
-
-/*!
-  @property
-
-  The minimum session duration (ms) that is tracked in automatic events.
+ The default value is 10000 (10 seconds).
  */
 @property (atomic) UInt64 minimumSessionDuration;
 
 /*!
-  @property
+ The maximum session duration (ms) that is tracked in automatic events.
 
-  The maximum session duration (ms) that is tracked in automatic events.
+ The default value is UINT64_MAX (no maximum session duration).
  */
 @property (atomic) UInt64 maximumSessionDuration;
+#endif
 
 /*!
- @property
-
- @abstract
  The a MixpanelDelegate object that can be used to assert fine-grain control
  over Mixpanel network activity.
 
- @discussion
  Using a delegate is optional. See the documentation for MixpanelDelegate
  below for more information.
  */
@@ -257,17 +225,12 @@
 #pragma mark Tracking
 
 /*!
- @method
+ Returns (and creates, if needed) a singleton instance of the API.
 
- @abstract
- Initializes and returns a singleton instance of the API.
-
- @discussion
- If you are only going to send data to a single Mixpanel project from your app,
- as is the common case, then this is the easiest way to use the API. This
- method will set up a singleton instance of the <code>Mixpanel</code> class for
- you using the given project token. When you want to make calls to Mixpanel
- elsewhere in your code, you can use <code>sharedInstance</code>.
+ This method will return a singleton instance of the <code>Mixpanel</code> class for
+ you using the given project token. If an instance does not exist, this method will create
+ one using <code>initWithToken:launchOptions:andFlushInterval:</code>. If you only have one
+ instance in your project, you can use <code>sharedInstance</code> to retrieve it.
 
  <pre>
  [Mixpanel sharedInstance] track:@"Something Happened"]];
@@ -283,13 +246,22 @@
 + (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken;
 
 /*!
- @method
+ Initializes a singleton instance of the API, uses it to set whether or not to opt out tracking for
+ GDPR compliance, and then returns it.
+ 
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the optOutTrackingByDefault parameter, Mixpanel tracking can be opted out by default.
+ 
+ @param apiToken        your project token
+ @param optOutTrackingByDefault  whether or not to be opted out from tracking by default
+ 
+ */
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken optOutTrackingByDefault:(BOOL)optOutTrackingByDefault;
 
- @abstract
+/*!
  Initializes a singleton instance of the API, uses it to track launchOptions information,
  and then returns it.
 
- @discussion
  This is the preferred method for creating a sharedInstance with a mixpanel
  like above. With the launchOptions parameter, Mixpanel can track referral
  information created by push notifications.
@@ -298,45 +270,104 @@
  @param launchOptions   your application delegate's launchOptions
 
  */
-+ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions;
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions;
 
 /*!
- @method
-
- @abstract
- Returns the previously instantiated singleton instance of the API.
-
- @discussion
- The API must be initialized with <code>sharedInstanceWithToken:</code> before
- calling this class method.
+ Initializes a singleton instance of the API, uses it to track launchOptions information,
+ and then returns it.
+ 
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the trackCrashes and automaticPushTracking parameter, Mixpanel can track crashes and automatic push.
+ 
+ @param apiToken        your project token
+ @param launchOptions   your application delegate's launchOptions
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
  */
-+ (Mixpanel *)sharedInstance;
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking;
 
 /*!
- @method
+ Initializes a singleton instance of the API, uses it to track launchOptions information,
+ and then returns it.
+ 
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the optOutTrackingByDefault parameter, Mixpanel tracking can be opted out by default.
+ 
+ @param apiToken        your project token
+ @param launchOptions   your application delegate's launchOptions
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
+ @param optOutTrackingByDefault  whether or not to be opted out from tracking by default
+ */
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking optOutTrackingByDefault:(BOOL)optOutTrackingByDefault;
 
- @abstract
+/*!
+ Returns a previously instantiated singleton instance of the API.
+
+ The API must be initialized with <code>sharedInstanceWithToken:</code> or
+ <code>initWithToken:launchOptions:andFlushInterval</code> before calling this class method.
+ This method will return <code>nil</code> if there are no instances created. If there is more than 
+ one instace, it will return the first one that was created by using <code>sharedInstanceWithToken:</code> 
+ or <code>initWithToken:launchOptions:andFlushInterval:</code>.
+ */
++ (nullable Mixpanel *)sharedInstance;
+
+/*!
+ Initializes an instance of the API with the given project token. This also sets
+ it as a shared instance so you can use <code>sharedInstance</code> or
+ <code>sharedInstanceWithToken:</code> to retrieve this object later.
+
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
+
+ @param apiToken        your project token
+ @param launchOptions   optional app delegate launchOptions
+ @param flushInterval   interval to run background flushing
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+                        issues with your crash reporting for either signals or exceptions
+ */
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes;
+
+/*!
+ Initializes an instance of the API with the given project token. This also sets
+ it as a shared instance so you can use <code>sharedInstance</code> or
+ <code>sharedInstanceWithToken:</code> to retrieve this object later.
+
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
+
+ @param apiToken        your project token
+ @param launchOptions   optional app delegate launchOptions
+ @param flushInterval   interval to run background flushing
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
+ */
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes
+        automaticPushTracking:(BOOL)automaticPushTracking;
+
+/*!
  Initializes an instance of the API with the given project token.
 
- @discussion
- Returns the a new API object. This allows you to create more than one instance
- of the API object, which is convenient if you'd like to send data to more than
- one Mixpanel project from a single app. If you only need to send data to one
- project, consider using <code>sharedInstanceWithToken:</code>.
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
 
  @param apiToken        your project token
  @param launchOptions   optional app delegate launchOptions
  @param flushInterval   interval to run background flushing
  */
-- (instancetype)initWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions andFlushInterval:(NSUInteger)flushInterval;
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+             andFlushInterval:(NSUInteger)flushInterval;
 
 /*!
- @method
-
- @abstract
  Initializes an instance of the API with the given project token.
 
- @discussion
  Supports for the old initWithToken method format but really just passes
  launchOptions to the above method as nil.
 
@@ -346,12 +377,8 @@
 - (instancetype)initWithToken:(NSString *)apiToken andFlushInterval:(NSUInteger)flushInterval;
 
 /*!
- @property
-
- @abstract
  Sets the distinct ID of the current user.
 
- @discussion
  As of version 2.3.1, Mixpanel will choose a default distinct ID based on
  whether you are using the AdSupport.framework or not.
 
@@ -387,9 +414,20 @@
 - (void)identify:(NSString *)distinctId;
 
 /*!
- @method
+ Sets the distinct ID of the current user. With the option of only updating the
+ distinct ID value and not the Mixpanel People distinct ID.
+ 
+ This method is not intended to be used unless you wish to prevent updating the Mixpanel
+ People distinct ID value by passing a value of NO to the usePeople param. This can be
+ useful if the user wishes to prevent People updates from being sent until the identify 
+ method is called.
+ 
+ @param distinctId string that uniquely identifies the current user
+ @param usePeople bool controls whether or not to set the people distinctId to the event distinctId
+ */
+- (void)identify:(NSString *)distinctId usePeople:(BOOL)usePeople;
 
- @abstract
+/*!
  Tracks an event.
 
  @param event           event name
@@ -397,12 +435,8 @@
 - (void)track:(NSString *)event;
 
 /*!
- @method
-
- @abstract
  Tracks an event with properties.
 
- @discussion
  Properties will allow you to segment your events in your Mixpanel reports.
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
@@ -413,33 +447,11 @@
  @param event           event name
  @param properties      properties dictionary
  */
-- (void)track:(NSString *)event properties:(NSDictionary *)properties;
-
-
-/*!
- @method
-
- @abstract
- Track a push notification using its payload sent from Mixpanel.
-
- @discussion
- To simplify user interaction tracking and a/b testing, Mixpanel
- automatically sends IDs for the relevant notification and a/b variants
- of each push. This method parses the standard payload and queues a
- track call using this information.
-
- @param userInfo         remote notification payload dictionary
- */
-- (void)trackPushNotification:(NSDictionary *)userInfo;
-
+- (void)track:(NSString *)event properties:(nullable NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties, overwriting ones that have already been set.
 
- @discussion
  Super properties, once registered, are automatically sent as properties for
  all event tracking calls. They save you having to maintain and add a common
  set of properties to your events. Property keys must be <code>NSString</code>
@@ -452,13 +464,9 @@
 - (void)registerSuperProperties:(NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties without overwriting ones that have already been
  set.
 
- @discussion
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
  <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
@@ -469,13 +477,9 @@
 - (void)registerSuperPropertiesOnce:(NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties without overwriting ones that have already been set
  unless the existing value is equal to defaultValue.
 
- @discussion
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
  <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
@@ -484,15 +488,11 @@
  @param properties      properties dictionary
  @param defaultValue    overwrite existing properties that have this value
  */
-- (void)registerSuperPropertiesOnce:(NSDictionary *)properties defaultValue:(id)defaultValue;
+- (void)registerSuperPropertiesOnce:(NSDictionary *)properties defaultValue:(nullable id)defaultValue;
 
 /*!
- @method
-
- @abstract
  Removes a previously registered super property.
 
- @discussion
  As an alternative to clearing all properties, unregistering specific super
  properties prevents them from being recorded on future events. This operation
  does not affect the value of other super properties. Any property name that is
@@ -507,29 +507,19 @@
 - (void)unregisterSuperProperty:(NSString *)propertyName;
 
 /*!
- @method
-
- @abstract
  Clears all currently set super properties.
  */
 - (void)clearSuperProperties;
 
 /*!
- @method
-
- @abstract
  Returns the currently set super properties.
  */
 - (NSDictionary *)currentSuperProperties;
 
 /*!
- @method
-
- @abstract
  Starts a timer that will be stopped and added as a property when a
  corresponding event is tracked.
 
- @discussion
  This method is intended to be used in advance of events that have
  a duration. For example, if a developer were to track an "Image Upload" event
  she might want to also know how long the upload took. Calling this method
@@ -554,28 +544,25 @@
 - (void)timeEvent:(NSString *)event;
 
 /*!
- @method
+ Retrieves the time elapsed for the named event since <code>timeEvent:</code> was called.
 
- @abstract
+ @param event   the name of the event to be tracked that was passed to <code>timeEvent:</code>
+ */
+- (double)eventElapsedTime:(NSString *)event;
+
+/*!
  Clears all current event timers.
  */
 - (void)clearTimedEvents;
 
 /*!
- @method
-
- @abstract
  Clears all stored properties and distinct IDs. Useful if your app's user logs out.
  */
 - (void)reset;
 
 /*!
- @method
-
- @abstract
  Uploads queued data to the Mixpanel server.
 
- @discussion
  By default, queued data is flushed to the Mixpanel servers every minute (the
  default for <code>flushInterval</code>), and on background (since
  <code>flushOnBackground</code> is on by default). You only need to call this
@@ -584,12 +571,8 @@
 - (void)flush;
 
 /*!
- @method
-
- @abstract
  Calls flush, then optionally archives and calls a handler when finished.
-
- @discussion
+ 
  When calling <code>flush</code> manually, it is sometimes important to verify
  that the flush has finished before further action is taken. This is
  especially important when the app is in the background and could be suspended
@@ -597,17 +580,15 @@
  <code>application:didReceiveRemoteNotification:fetchCompletionHandler:</code>
  are called when an app is brought to the background and require a handler to
  be called when it finishes.
+
+ @param handler     completion handler to be called after flush completes
  */
-- (void)flushWithCompletion:(void (^)())handler;
+- (void)flushWithCompletion:(nullable void (^)(void))handler;
 
 /*!
- @method
-
- @abstract
  Writes current project info, including distinct ID, super properties and pending event
  and People record queues to disk.
 
- @discussion
  This state will be recovered when the app is launched again if the Mixpanel
  library is initialized with the same project token. <b>You do not need to call
  this method</b>. The library listens for app state changes and handles
@@ -617,18 +598,13 @@
 - (void)archive;
 
 /*!
- @method
-
- @abstract
  Creates a distinct_id alias from alias to original id.
 
- @discussion
  This method is used to map an identifier called an alias to the existing Mixpanel
  distinct id. This causes all events and people requests sent with the alias to be
  mapped back to the original distinct id. The recommended usage pattern is to call
- both createAlias: and identify: when the user signs up, and only identify: (with
- their new user ID) when they log in. This will keep your signup funnels working
- correctly.
+ createAlias: and then identify: (with their new user ID) when they log in the next time.
+ This will keep your signup funnels working correctly.
 
  <pre>
  // This makes the current ID (an auto-generated GUID)
@@ -646,59 +622,102 @@
  */
 - (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID;
 
+/*!
+ Creates a distinct_id alias from alias to original id.
+
+ This method is not intended to be used unless you wish to prevent updating the Mixpanel
+ People distinct ID value by passing a value of NO to the usePeople param. This can be
+ useful if the user wishes to prevent People updates from being sent until the identify
+ method is called.
+
+ @param alias         the new distinct_id that should represent original
+ @param distinctID     the old distinct_id that alias will be mapped to
+ @param usePeople bool controls whether or not to set the people distinctId to the event distinctId
+ */
+- (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID usePeople:(BOOL)usePeople;
+
+/*!
+ Returns the Mixpanel library version number as a string, e.g. "3.2.3".
+ */
 - (NSString *)libVersion;
 
-
-#if !defined(MIXPANEL_APP_EXTENSION)
-#pragma mark - Mixpanel Surveys
+/*!
+ Opt out tracking.
+ 
+ This method is used to opt out tracking. This causes all events and people request no longer
+ to be sent back to the Mixpanel server.
+ */
+- (void)optOutTracking;
 
 /*!
- @method
-
- @abstract
- Shows the survey with the given name.
-
- @discussion
- This method allows you to explicitly show a named survey at the time of your choosing.
-
+ Opt in tracking.
+ 
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
+ 
+ This method will internally track an opt in event to your project. If you want to identify the opt-in
+ event and/or pass properties to the event, See also <code>optInTrackingForDistinctId:</code> and
+ <code>optInTrackingForDistinctId:withEventProperties:</code>.
  */
-- (void)showSurveyWithID:(NSUInteger)ID;
+- (void)optInTracking;
 
 /*!
- @method
-
- @abstract
- Show a survey if one is available.
-
- @discussion
- This method allows you to display the first available survey targeted to the currently
- identified user at the time of your choosing. You would typically pair this with
- setting <code>showSurveyOnActive = NO;</code> so that the survey won't show automatically.
-
+ Opt in tracking.
+ 
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
+ 
+ This method will internally track an opt in event to your project. If you want to pass properties to the event, see also
+ <code>optInTrackingForDistinctId:withEventProperties:</code>.
+ 
+ @param distinctID     optional string to use as the distinct ID for events. This will call <code>identify:</code>.
+ If you use people profiles make sure you manually call <code>identify:</code> after this method.
  */
-- (void)showSurvey;
+- (void)optInTrackingForDistinctID:(nullable NSString *)distinctID;
 
+/*!
+ Opt in tracking.
+ 
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
+ 
+ This method will internally track an opt in event to your project.See also <code>optInTracking</code> or
+ <code>optInTrackingForDistinctId:</code>.
+ 
+ @param distinctID     optional string to use as the distinct ID for events. This will call <code>identify:</code>.
+ If you use people profiles make sure you manually call <code>identify:</code> after this method.
+ @param properties     optional properties dictionary that could be passed to add properties to the opt-in event that is sent to
+ Mixpanel.
+ */
+- (void)optInTrackingForDistinctID:(nullable NSString *)distinctID withEventProperties:(nullable NSDictionary *)properties;
+
+/*!
+ Returns YES if the current user has opted out tracking, NO if the current user has opted in tracking.
+ */
+- (BOOL)hasOptedOutTracking;
+
+/*!
+ Returns the Mixpanel library version number as a string, e.g. "3.2.3".
+ */
++ (NSString *)libVersion;
+
+
+#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 #pragma mark - Mixpanel Notifications
 
 /*!
- @method
-
- @abstract
  Shows the notification of the given id.
 
- @discussion
  You do not need to call this method on the main thread.
+
+ @param ID      notification id
  */
 - (void)showNotificationWithID:(NSUInteger)ID;
 
 
 /*!
- @method
-
- @abstract
  Shows a notification with the given type if one is available.
 
- @discussion
  You do not need to call this method on the main thread.
 
  @param type The type of notification to show, either @"mini", or @"takeover"
@@ -706,12 +725,8 @@
 - (void)showNotificationWithType:(NSString *)type;
 
 /*!
- @method
-
- @abstract
  Shows a notification if one is available.
 
- @discussion
  You do not need to call this method on the main thread.
  */
 - (void)showNotification;
@@ -719,12 +734,8 @@
 #pragma mark - Mixpanel A/B Testing
 
 /*!
- @method
-
- @abstract
  Join any experiments (A/B tests) that are available for the current user.
 
- @discussion
  Mixpanel will check for A/B tests automatically when your app enters
  the foreground. Call this method if you would like to to check for,
  and join, any experiments are newly available for the current user.
@@ -734,324 +745,43 @@
 - (void)joinExperiments;
 
 /*!
- @method
-
- @abstract
  Join any experiments (A/B tests) that are available for the current user.
 
- @discussion
  Same as joinExperiments but will fire the given callback after all experiments
  have been loaded and applied.
+
+ @param experimentsLoadedCallback       callback to be called after experiments
+                                        joined and applied
  */
-- (void)joinExperimentsWithCallback:(void(^)())experimentsLoadedCallback;
+- (void)joinExperimentsWithCallback:(nullable void (^)(void))experimentsLoadedCallback;
 
-#endif
+#endif // MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 
-@end
-
+#pragma mark - Deprecated
 /*!
- @class
- Mixpanel People API.
-
- @abstract
- Access to the Mixpanel People API, available as a property on the main
- Mixpanel API.
-
- @discussion
- <b>You should not instantiate this object yourself.</b> An instance of it will
- be available as a property of the main Mixpanel object. Calls to Mixpanel
- People methods will look like this:
-
- <pre>
- [mixpanel.people increment:@"App Opens" by:1];
- </pre>
-
- Please note that the core <code>Mixpanel</code> and
- <code>MixpanelPeople</code> classes share the <code>identify:</code> method.
- The <code>Mixpanel</code> <code>identify:</code> affects the
- <code>distinct_id</code> property of events sent by <code>track:</code> and
- <code>track:properties:</code> and determines which Mixpanel People user
- record will be updated by <code>set:</code>, <code>increment:</code> and other
- <code>MixpanelPeople</code> methods.
-
- <b>If you are going to set your own distinct IDs for core Mixpanel event
- tracking, make sure to use the same distinct IDs when using Mixpanel
- People</b>.
+ Current user's name in Mixpanel Streams.
  */
-@interface MixpanelPeople : NSObject
-/*!
- @property
-
- @abstract
- controls the $ignore_time property in any subsequent MixpanelPeople operation.
-
- If the $ignore_time property is present and true in your request,
- Mixpanel will not automatically update the "Last Seen" property of the profile.
- Otherwise, Mixpanel will add a "Last Seen" property associated with the
- current time for all $set, $append, and $add operations
-
- @discussion
- Defaults to NO.
- */
-@property (atomic) BOOL ignoreTime;
-
-/*!
- @method
-
- @abstract
- Register the given device to receive push notifications.
-
- @discussion
- This will associate the device token with the current user in Mixpanel People,
- which will allow you to send push notifications to the user from the Mixpanel
- People web interface. You should call this method with the <code>NSData</code>
- token passed to
- <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>.
-
- @param deviceToken     device token as returned <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>
- */
-- (void)addPushDeviceToken:(NSData *)deviceToken;
-
-/*!
- @method
-
- @abstract
- Unregister the given device to receive push notifications.
-
- @discussion
- This will unset all of the push tokens saved to this people profile. This is useful
- in conjunction with a call to `reset`, or when a user is logging out.
- */
-- (void)removeAllPushDeviceTokens;
-
-/*!
- @method
-
- @abstract
- Unregister a specific device token from the ability to receive push notifications.
-
- @discussion
- This will remove the provided push token saved to this people profile. This is useful
- in conjunction with a call to `reset`, or when a user is logging out.
- */
-- (void)removePushDeviceToken:(NSData *)deviceToken;
-
-/*!
- @method
-
- @abstract
- Set properties on the current user in Mixpanel People.
-
- @discussion
- The properties will be set on the current user. The keys must be NSString
- objects and the values should be NSString, NSNumber, NSArray, NSDate, or
- NSNull objects. We use an NSAssert to enforce this type requirement. In
- release mode, the assert is stripped out and we will silently convert
- incorrect types to strings using [NSString stringWithFormat:@"%@", value]. You
- can override the default the current project token and distinct ID by
- including the special properties: $token and $distinct_id. If the existing
- user record on the server already has a value for a given property, the old
- value is overwritten. Other existing properties will not be affected.
-
- <pre>
- // applies to both Mixpanel Engagement track: AND Mixpanel People set: and
- // increment: calls
- [mixpanel identify:distinctId];
- </pre>
-
- @param properties       properties dictionary
-
- */
-- (void)set:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Convenience method for setting a single property in Mixpanel People.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param property        property name
- @param object          property value
- */
-- (void)set:(NSString *)property to:(id)object;
-
-/*!
- @method
-
- @abstract
- Set properties on the current user in Mixpanel People, but don't overwrite if
- there is an existing value.
-
- @discussion
- This method is identical to <code>set:</code> except it will only set
- properties that are not already set. It is particularly useful for collecting
- data about the user's initial experience and source, as well as dates
- representing the first time something happened.
-
- @param properties       properties dictionary
-
- */
-- (void)setOnce:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Remove a list of properties and their values from the current user's profile
- in Mixpanel People.
-
- @discussion
- The properties array must ony contain NSString names of properties. For properties
- that don't exist there will be no effect.
-
- @param properties       properties array
-
- */
-- (void)unset:(NSArray *)properties;
-
-/*!
- @method
-
- @abstract
- Increment the given numeric properties by the given values.
-
- @discussion
- Property keys must be NSString names of numeric properties. A property is
- numeric if its current value is a number. If a property does not exist, it
- will be set to the increment amount. Property values must be NSNumber objects.
-
- @param properties      properties dictionary
- */
-- (void)increment:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Convenience method for incrementing a single numeric property by the specified
- amount.
-
- @param property        property name
- @param amount          amount to increment by
- */
-- (void)increment:(NSString *)property by:(NSNumber *)amount;
-
-/*!
- @method
-
- @abstract
- Append values to list properties.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param properties      mapping of list property names to values to append
- */
-- (void)append:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Union list properties.
-
- @discussion
- Property keys must be <code>NSArray</code> objects.
-
- @param properties      mapping of list property names to lists to union
- */
-- (void)union:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Remove list properties.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param properties      mapping of list property names to values to remove
- */
-- (void)remove:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Track money spent by the current user for revenue analytics.
-
- @param amount          amount of revenue received
- */
-- (void)trackCharge:(NSNumber *)amount;
-
-/*!
- @method
-
- @abstract
- Track money spent by the current user for revenue analytics and associate
- properties with the charge.
-
- @discussion
- Charge properties allow you segment on types of revenue. For instance, you
- could record a product ID with each charge so that you could segment on it in
- revenue analytics to see which products are generating the most revenue.
- */
-- (void)trackCharge:(NSNumber *)amount withProperties:(nullable NSDictionary *)properties;
-
-
-/*!
- @method
-
- @abstract
- Delete current user's revenue history.
- */
-- (void)clearCharges;
-
-/*!
- @method
-
- @abstract
- Delete current user's record from Mixpanel People.
- */
-- (void)deleteUser;
+@property (nullable, atomic, copy) NSString *nameTag __deprecated; // Deprecated in v3.0.1
 
 @end
 
 /*!
  @protocol
 
- @abstract
  Delegate protocol for controlling the Mixpanel API's network behavior.
 
- @discussion
  Creating a delegate for the Mixpanel object is entirely optional. It is only
  necessary when you want full control over when data is uploaded to the server,
  beyond simply calling stop: and start: before and after a particular block of
  your code.
  */
+
 @protocol MixpanelDelegate <NSObject>
+
 @optional
-
 /*!
- @method
-
- @abstract
  Asks the delegate if data should be uploaded to the server.
 
- @discussion
  Return YES to upload now, NO to defer until later.
 
  @param mixpanel        Mixpanel API instance
@@ -1059,3 +789,5 @@
 - (BOOL)mixpanelWillFlush:(Mixpanel *)mixpanel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/RNMixpanel/RNMixpanel.h
+++ b/RNMixpanel/RNMixpanel.h
@@ -11,5 +11,5 @@
 @interface RNMixpanel : NSObject<RCTBridgeModule>
 
 + (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions;
-
++ (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking optOutTrackingByDefault:(BOOL)optOutTrackingByDefault;
 @end

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -46,6 +46,33 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
     }
 }
 
+// sharedInstanceWithToken
+RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken 
+                  launchOptions:(nullable NSDictionary *)launchOptions
+                  trackCrashes:(BOOL)trackCrashes
+                  automaticPushTracking:(BOOL)automaticPushTracking
+                  optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    @synchronized(self) {
+        if (instances != nil && [instances objectForKey:apiToken] != nil) {
+            resolve(nil);
+            return;
+        }
+        Mixpanel *instance = [Mixpanel sharedInstanceWithToken:apiToken
+                                                 launchOptions:launchOptions
+                                                  trackCrashes:trackCrashes
+                                         automaticPushTracking:automaticPushTracking
+                                       optOutTrackingByDefault:optOutTrackingByDefault];
+        // copy instances and add the new instance.  then reassign instances
+        NSMutableDictionary *newInstances = [NSMutableDictionary dictionaryWithDictionary:instances];
+        [newInstances setObject:instance forKey:apiToken];
+        instances = [NSDictionary dictionaryWithDictionary:newInstances];
+        [instance applicationDidBecomeActive:nil];
+        resolve(nil);
+    }
+}
+
 // setAppSessionProperties iOS
 // setAppSessionProperties iOS
 RCT_EXPORT_METHOD(setAppSessionPropertiesIOS:(NSDictionary *)properties) {

--- a/index.js
+++ b/index.js
@@ -18,9 +18,16 @@ However since React Native makes no guarantees about whether native methods are 
 export class MixpanelInstance {
   apiToken: ?string
   initialized: boolean
-
-  constructor(apiToken: ?string) {
+  launchOptions: object
+  trackCrashes: boolean
+  automaticPushTracking: boolean
+  optOutTrackingByDefault: boolean
+  constructor(apiToken: ?string, launchOptions?: Object, trackCrashes?: boolean, automaticPushTracking?: boolean, optOutTrackingByDefault?: boolean) {
     this.apiToken = apiToken
+    this.launchOptions = launchOptions === undefined || null
+    this.trackCrashes = trackCrashes === undefined || true
+    this.automaticPushTracking = automaticPushTracking === undefined || true
+    this.optOutTrackingByDefault = optOutTrackingByDefault === undefined || true
     this.initialized = false
   }
 
@@ -28,7 +35,7 @@ export class MixpanelInstance {
   Initializes the instance in native land.  Returns a promise that resolves when the instance has been created and is ready for use.
   */
   initialize(): Promise<void> {
-    return RNMixpanel.sharedInstanceWithToken(this.apiToken)
+    return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.launchOptions, this.trackCrashes, this.automaticPushTracking, this.optOutTrackingByDefault)
       .then(() => {
         this.initialized = true
       })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // @flow
 'use strict'
-import { NativeModules } from 'react-native'
+import { NativeModules,Platform } from 'react-native'
 const { RNMixpanel } = NativeModules
 
 /*
@@ -35,10 +35,17 @@ export class MixpanelInstance {
   Initializes the instance in native land.  Returns a promise that resolves when the instance has been created and is ready for use.
   */
   initialize(): Promise<void> {
-    return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.launchOptions, this.trackCrashes, this.automaticPushTracking, this.optOutTrackingByDefault)
+    if (Platform.OS === 'ios'){
+      return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.launchOptions, this.trackCrashes, this.automaticPushTracking, this.optOutTrackingByDefault)
       .then(() => {
         this.initialized = true
       })
+    }else {
+      return RNMixpanel.sharedInstanceWithToken(this.apiToken)
+      .then(() => {
+        this.initialized = true
+      })
+    }
   }
 
   /*

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export class MixpanelInstance {
     this.launchOptions = launchOptions === undefined || null
     this.trackCrashes = trackCrashes === undefined || true
     this.automaticPushTracking = automaticPushTracking === undefined || true
-    this.optOutTrackingByDefault = optOutTrackingByDefault === undefined || true
+    this.optOutTrackingByDefault = optOutTrackingByDefault === undefined || false
     this.initialized = false
   }
 
@@ -206,8 +206,8 @@ mixpanel.track('my event')
 */
 export default {
 
-  sharedInstanceWithToken(apiToken: string): Promise<void> {
-    const instance = new MixpanelInstance(apiToken)
+  sharedInstanceWithToken(apiToken: string, launchOptions?: Object, trackCrashes?: boolean, automaticPushTracking?: boolean, optOutTrackingByDefault?: boolean): Promise<void> {
+    const instance = new MixpanelInstance(apiToken,launchOptions,trackCrashes,automaticPushTracking,optOutTrackingByDefault)
     if (!defaultInstance) defaultInstance = instance
     return instance.initialize()
   },

--- a/index.js
+++ b/index.js
@@ -24,10 +24,10 @@ export class MixpanelInstance {
   optOutTrackingByDefault: boolean
   constructor(apiToken: ?string, launchOptions?: Object, trackCrashes?: boolean, automaticPushTracking?: boolean, optOutTrackingByDefault?: boolean) {
     this.apiToken = apiToken
-    this.launchOptions = launchOptions === undefined || null
-    this.trackCrashes = trackCrashes === undefined || true
-    this.automaticPushTracking = automaticPushTracking === undefined || true
-    this.optOutTrackingByDefault = optOutTrackingByDefault === undefined || false
+    this.launchOptions = launchOptions === undefined ? null : launchOptions
+    this.trackCrashes = trackCrashes === undefined ? true : trackCrashes
+    this.automaticPushTracking = automaticPushTracking === undefined ? true : automaticPushTracking
+    this.optOutTrackingByDefault = optOutTrackingByDefault === undefined ? false : optOutTrackingByDefault
     this.initialized = false
   }
 


### PR DESCRIPTION
I need disable mixpanel's `trackCrashes` feature, so I checked mixpanel native SDK, found out they had supported more initialize options methods.

So I updated header file and add more optional parameters on constructor method. 