### PR TITLE
Reverting podspec to Mixpanel 3.3.9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.mixpanel.android:mixpanel-android:5.3.0"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.mixpanel.android:mixpanel-android:5.3.0"
 }

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "7.0"
-  s.dependency 'Mixpanel'
+  s.dependency 'Mixpanel', '~> 3.3.9'
   s.dependency 'React'
 end


### PR DESCRIPTION
Please refer to [this issue](https://github.com/davodesign84/react-native-mixpanel/issues/172) for more information.