### PR TITLE
Add push / registration methods; update readme and typescript defs; add tvOS support, update iOS and Android SDK; make podspec package.json driven; add fine grained in-app message control; add opt in / out tracking; add autolinking information; Expose iOS params that can be passed on Mixpanel instance initalization: trackCrashes, automaticPushTracking, launchOptions; add Changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ local.properties
 #
 node_modules/
 npm-debug.log
+*.prefs
+android/.project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.10
+
+- Fix typo
+
 # 1.1.9
 
 - Expose iOS params that can be passed on Mixpanel instance initalization: trackCrashes, automaticPushTracking, launchOptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# 1.1.8
+
+- Add support for AppleTV
+- Add information about Autolinking from RN >= 0.60
+- Update podspec to be package.json driven
+- Add fine grained in-app message control
+- Update iOS SDK to 3.5.0
+- Update Android SDK to 5.6.5
+- Add opt in / opt out tracking option
+- Add push / registration methods
+- Update README
+- Update Typescript defs
+- Fix crash on clearPushRegistrationId

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.9
+
+- Expose iOS params that can be passed on Mixpanel instance initalization: trackCrashes, automaticPushTracking, launchOptions
+- Update Typescript defs and readme
+
 # 1.1.8
 
 - Add support for AppleTV

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ Mixpanel.track("Event name");
 //Track event with properties
 Mixpanel.trackWithProperties('Click Button', {button_type: 'yellow button', button_text: 'magic button'});
 
-//Create Alias from unique id
+//Create Alias from unique id, i.e. create a new mixpanel profile: to call when a user signs up, with a unique id that is not used by another mixpanel profile as param
 Mixpanel.createAlias(UNIQUE_ID)
 
-//Identify
+//Identify, i.e. associate to an existing mixpanel profile: to call when a user logs in and is already registered in Mixpanel with this unique id
 Mixpanel.identify(UNIQUE_ID)
 
-//Set People properties
+//Set People properties (warning: if no mixpanel profile has been assigned to the current user when this method is called, it will automatically create a new mixpanel profile and the user will no longer be anonymous in Mixpanel)
 Mixpanel.set({"$email": "elvis@email.com"});
 
-//Set People Properties Once
+//Set People Properties Once (warning: if no mixpanel profile has been assigned to the current user when this method is called, it will automatically create a new mixpanel profile and the user will no longer be anonymous in Mixpanel)
 Mixpanel.setOnce({"$email": "elvis@email.com", "Created": new Date().toISOString()});
 
 // Timing Events
@@ -133,7 +133,7 @@ Mixpanel.clearPushRegistrationId();
 // iOS
 Mixpanel.addPushDeviceToken("APNS push token")
 
-// Mixpanel reset method
+// Mixpanel reset method (warning: it will also generate a new unique id and call the identify method with it. Thus, the user will not be anonymous in Mixpanel.)
 Mixpanel.reset();
 
 // get the last distinct id set with identify or, if identify hasn't been

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Mixpanel.increment("Login Count", 1);
 
 // Android
 // Retrieves current Firebase Cloud Messaging token.
+// Should only be called after identify(String) has been called.
 Mixpanel.getPushRegistrationId();
 
 // send push notifications token to Mixpanel

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![npm](https://img.shields.io/npm/dt/react-native-mixpanel.svg?style=for-the-badge)
+
+![npm](https://img.shields.io/npm/dm/react-native-mixpanel.svg?style=for-the-badge)
+
+
 # Description
 React Native wrapper for Mixpanel library, on top of the regular javascript sdk you can normally use, this provides you all the goodies of the native wrapper including notifications, analysis of the operating system, surveys etc..
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Mixpanel.addPushDeviceToken("APNS push token");
 // iOS - unregister iOS device, pushDeviceToken = APNS push token
 Mixpanel.removePushDeviceToken(pushDeviceToken: string); 
 
+// iOS
+// Unregister the given device to receive push notifications.
+Mixpanel.removeAllPushDeviceTokens();
+
 // Mixpanel reset method (warning: it will also generate a new unique id and call the identify method with it. Thus, the user will not be anonymous in Mixpanel.)
 Mixpanel.reset();
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ From version 1.1.2 module uses Mixpanel SDK >= 5.6.0 that requires FCM
 
 Autolinking should work out of the box.
 
+Remember to do: pod install.
+
 # Manual Installation
 
 ## Installation iOS ##

--- a/README.md
+++ b/README.md
@@ -81,11 +81,27 @@ public class MainActivity extends ReactActivity {
 # Usage
 
 ```js
-//Require the module
+// Require the module
 var Mixpanel = require('react-native-mixpanel');
 
-//Init Mixpanel SDK with your project token
+// Init Mixpanel SDK with your project token
+//  @param apiToken - your project token
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (false by default)
 Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN);
+
+// You can also opt out tracking by default (GDPR)
+//  @param apiToken - your project token
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, true);
+
+// Opt in tracking.
+// Use this method to opt in an already opted out user from tracking. People updates and track calls will be sent to Mixpanel after using this method.
+Mixpanel.optInTracking();
+
+//  Opt out tracking.
+
+//  This method is used to opt out tracking. This causes all events and people request no longer to be sent back to the Mixpanel server.
+Mixpanel.optOutTracking();
 
 //Send and event name with no properties
 Mixpanel.track("Event name");

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Mixpanel.initPushHandling(YOUR_12_DIGIT_GOOGLE_SENDER_ID);
 Mixpabel.clearSuperProperties();
 
 // Unregister an android device for push notifications [Android only]
+// With token it will clear a single Firebase Cloud Messaging token from Mixpanel.
+// Without token it will clear all current Firebase Cloud Messaging tokens from Mixpanel.
 Mixpanel.clearPushRegistrationId(token?: string); 
 
 // iOS

--- a/README.md
+++ b/README.md
@@ -207,5 +207,31 @@ Mixpanel.reset();
 Mixpanel.getDistinctId(function(id){})
 ```
 
+## Displaying in-app messages ##
+
+By default, in-app messages are shown to users when the app starts and a message is available to display
+This behaviour can be disabled by default, and explicitally triggered at a later time (e.g. after your loading sequence)
+
+For iOS, in your app delegate, add the following line:
+
+```
+// In application:didFinishLaunchingWithOptions:
+Mixpanel *mixpanel = [Mixpanel sharedInstanceWithToken:YOUR_MIXPANEL_TOKEN];
+// Turn this off so the message doesn't pop up automatically.
+mixpanel.showNotificationOnActive = NO;
+```
+
+For Android, add the following to your app mainifest in the `<application>` tag:
+
+```
+<meta-data android:name="com.mixpanel.android.MPConfig.AutoShowMixpanelUpdates" android:value="false" />
+```
+
+You can then call the following in your react native application:
+
+```
+Mixpanel.showInAppMessageIfAvailable();
+```
+
 ## Notes ##
 For more info please have a look at the [official Mixpanel reference](https://mixpanel.com/help/reference/ios) for iOS

--- a/README.md
+++ b/README.md
@@ -134,11 +134,17 @@ Mixpanel.setPushRegistrationId("GCM/FCM push token");
 //make sure you call this right after you call `identify`
 Mixpanel.initPushHandling(YOUR_12_DIGIT_GOOGLE_SENDER_ID);
 
-//unregister a device for push notifications
-Mixpanel.clearPushRegistrationId();
+// Allows to clear super properites
+Mixpabel.clearSuperProperties();
+
+// Unregister an android device for push notifications [Android only]
+Mixpanel.clearPushRegistrationId(token?: string); 
 
 // iOS
-Mixpanel.addPushDeviceToken("APNS push token")
+Mixpanel.addPushDeviceToken("APNS push token");
+
+// iOS - unregister iOS device, pushDeviceToken = APNS push token
+Mixpanel.removePushDeviceToken(pushDeviceToken: string); 
 
 // Mixpanel reset method (warning: it will also generate a new unique id and call the identify method with it. Thus, the user will not be anonymous in Mixpanel.)
 Mixpanel.reset();

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Mixpanel.trackChargeWithProperties(399, {"product": "ACME Wearable tech"});
 // increment property
 Mixpanel.increment("Login Count", 1);
 
+// Append array to a list property
+Mixpanel.append("Lines", ["Simple", "Dashed"]);
+
+// Merge array to a list property, excluding duplicate values
+Mixpanel.union("Lines", ["Dashed", "Custom"]);
+
 // Android
 // Retrieves current Firebase Cloud Messaging token.
 // Should only be called after identify(String) has been called.

--- a/README.md
+++ b/README.md
@@ -126,18 +126,58 @@ Mixpanel.trackChargeWithProperties(399, {"product": "ACME Wearable tech"});
 // increment property
 Mixpanel.increment("Login Count", 1);
 
+// Android
+// Retrieves current Firebase Cloud Messaging token.
+Mixpanel.getPushRegistrationId();
+
 // send push notifications token to Mixpanel
 // Android
 Mixpanel.setPushRegistrationId("GCM/FCM push token");
 
-//tell Mixpanel which user record in People Analytics should receive the messages when they are sent from the Mixpanel app,
-//make sure you call this right after you call `identify`
+// Android
+// tell Mixpanel which user record in People Analytics should receive the messages when they are sent from the Mixpanel app,
+// make sure you call this right after you call `identify`
+// Deprecated. 
+// in 5.5.0. Google Cloud Messaging (GCM) is now deprecated by Google. To enable end-to-end Firebase Cloud Messaging (FCM) from Mixpanel you only need to add the following to your application manifest XML file:
+
+ 
+//  <service
+//        android:name="com.mixpanel.android.mpmetrics.MixpanelFCMMessagingService"
+//        android:enabled="true"
+//        android:exported="false">
+//        <intent-filter>
+//            <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+//        </intent-filter>
+//  </service>
+ 
+ 
+
+// Make sure you have a valid google-services.json file in your project and firebase messaging is included as a dependency. Example:
+
+ 
+//  buildscript {
+//       ...
+//       dependencies {
+//           classpath 'com.google.gms:google-services:4.1.0'
+//           ...
+//       }
+//  }
+
+//  dependencies {
+//      implementation 'com.google.firebase:firebase-messaging:17.3.4'
+//      implementation 'com.mixpanel.android:mixpanel-android:5.5.0'
+//  }
+
+//  apply plugin: 'com.google.gms.google-services'
+
+// We recommend you update your Server Key on mixpanel.com from your Firebase console. Legacy server keys are still supported.
 Mixpanel.initPushHandling(YOUR_12_DIGIT_GOOGLE_SENDER_ID);
 
 // Allows to clear super properites
 Mixpabel.clearSuperProperties();
 
-// Unregister an android device for push notifications [Android only]
+// Android
+// Unregister an android device for push notifications
 // With token it will clear a single Firebase Cloud Messaging token from Mixpanel.
 // Without token it will clear all current Firebase Cloud Messaging tokens from Mixpanel.
 Mixpanel.clearPushRegistrationId(token?: string); 

--- a/README.md
+++ b/README.md
@@ -92,13 +92,33 @@ var Mixpanel = require('react-native-mixpanel');
 
 // Init Mixpanel SDK with your project token
 //  @param apiToken - your project token
-//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (false by default)
 Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN);
 
 // You can also opt out tracking by default (GDPR)
 //  @param apiToken - your project token
-//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default
-Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, true);
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (default value: false)
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, false);
+
+// You can also disable trackCrashes
+//  @param apiToken - your project token
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (default value: false)
+//  @param trackCrashes (iOS only!) - whether or not to track crashes in Mixpanel. may want to disable if you're seeing  issues with your crash reporting for either signals or exceptions (default value: true)
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, false, true);
+
+// You can also disable automaticPushTracking
+//  @param apiToken - your project token
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (default value: false)
+//  @param trackCrashes (iOS only!) - whether or not to track crashes in Mixpanel. may want to disable if you're seeing  issues with your crash reporting for either signals or exceptions (default value: true)
+//  @param automaticPushTracking (iOS only!) - whether or not to automatically track pushes sent from Mixpanel (default value: true)
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, false, true, true);
+
+// You can also pass launchOptions
+//  @param apiToken - your project token
+//  @param optOutTrackingByDefault - whether or not to be opted out from tracking by default (default value: false)
+//  @param trackCrashes (iOS only!) - whether or not to track crashes in Mixpanel. may want to disable if you're seeing  issues with your crash reporting for either signals or exceptions (default value: true)
+//  @param automaticPushTracking (iOS only!) - whether or not to automatically track pushes sent from Mixpanel (default value: true)
+//  @param launchOptions (iOS only!) - your application delegate's launchOptions (default value: null)
+Mixpanel.sharedInstanceWithToken(YOUR_PROJECT_TOKEN, false, true, true, null);
 
 // Opt in tracking.
 // Use this method to opt in an already opted out user from tracking. People updates and track calls will be sent to Mixpanel after using this method.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ From version 1.1.2 module uses Mixpanel SDK >= 5.6.0 that requires FCM
 - Allow sub-classes to override push notifications payload and Support when more than one push provider is used [more info here](https://github.com/mixpanel/mixpanel-android/releases/tag/v5.5.1)
 
 
+# Autolinking and RN >= 0.60
+
+Autolinking should work out of the box.
+
 # Manual Installation
 
 ## Installation iOS ##

--- a/RNMixpanel.xcodeproj/project.pbxproj
+++ b/RNMixpanel.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		5EAEEA411F0555B100C6FED8 /* libRNMixpanel-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libRNMixpanel-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E78DD5BC2364BED0009197B6 /* MixpanelPeople.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelPeople.h; sourceTree = "<group>"; };
 		FDC64AF01BF1690D0044C1B4 /* libRNMixpanel.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNMixpanel.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDC64AF31BF1690D0044C1B4 /* RNMixpanel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNMixpanel.h; sourceTree = "<group>"; };
 		FDC64AF51BF1690D0044C1B4 /* RNMixpanel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNMixpanel.m; sourceTree = "<group>"; };
@@ -86,6 +87,7 @@
 		FDC64AF21BF1690D0044C1B4 /* RNMixpanel */ = {
 			isa = PBXGroup;
 			children = (
+				E78DD5BC2364BED0009197B6 /* MixpanelPeople.h */,
 				FDDAC2A11BF2B66500E70D3C /* Mixpanel.h */,
 				FDC64AF31BF1690D0044C1B4 /* RNMixpanel.h */,
 				FDC64AF51BF1690D0044C1B4 /* RNMixpanel.m */,
@@ -153,6 +155,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = FDC64AE71BF1690D0044C1B4;

--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -95,6 +95,21 @@
 
 /*!
  @property
+ 
+ @abstract
+ Controls whether to automatically send the client IP Address as part of
+ event tracking. With an IP address, geo-location is possible down to neighborhoods
+ within a city, although the Mixpanel Dashboard will just show you city level location
+ specificity. For privacy reasons, you may be in a situation where you need to forego
+ effectively having access to such granular location information via the IP Address.
+ 
+ @discussion
+ Defaults to YES.
+ */
+@property (atomic) BOOL useIPAddressForGeoLocation;
+
+/*!
+ @property
 
  @abstract
  Control whether the library should flush data to Mixpanel when the app

--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -1,18 +1,49 @@
 #import <Foundation/Foundation.h>
-
+#if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#else
+#import <Cocoa/Cocoa.h>
+#endif
+#import "MixpanelPeople.h"
+#import "MixpanelType.h"
+
+
+#if defined(MIXPANEL_WATCHOS)
+#define MIXPANEL_FLUSH_IMMEDIATELY 1
+#define MIXPANEL_NO_APP_LIFECYCLE_SUPPORT 1
+#endif
+
+#if (defined(MIXPANEL_WATCHOS) || defined(MIXPANEL_MACOS))
+#define MIXPANEL_NO_UIAPPLICATION_ACCESS 1
+#endif
+
+#if (defined(MIXPANEL_TVOS) || defined(MIXPANEL_WATCHOS) || defined(MIXPANEL_MACOS))
+#define MIXPANEL_NO_REACHABILITY_SUPPORT 1
+#define MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT 1
+#define MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT 1
+#define MIXPANEL_NO_CONNECT_INTEGRATION_SUPPORT 1
+#endif
 
 @class    MixpanelPeople;
+@class    MixpanelGroup;
 @protocol MixpanelDelegate;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
- @class
+ A string constant "mini" that respresent Mini Notification
+ */
+extern NSString *const MPNotificationTypeMini;
+/*!
+ A string constant "takeover" that respresent Takeover Notification
+ */
+extern NSString *const MPNotificationTypeTakeover;
+
+/*!
  Mixpanel API.
 
- @abstract
  The primary interface for integrating Mixpanel with your app.
 
- @discussion
  Use the Mixpanel class to set up your project and track events in Mixpanel
  Engagement. It now also includes a <code>people</code> property for accessing
  the Mixpanel People API.
@@ -25,7 +56,7 @@
  [mixpanel track:@"Button Clicked"];
 
  // Set properties on a user in Mixpanel People
- [mixpanel.people identify:@"CURRENT USER DISTINCT ID"];
+ [mixpanel identify:@"CURRENT USER DISTINCT ID"];
  [mixpanel.people set:@"Plan" to:@"Premium"];
  </pre>
 
@@ -38,138 +69,93 @@
 #pragma mark Properties
 
 /*!
- @property
-
- @abstract
  Accessor to the Mixpanel People API object.
 
- @discussion
  See the documentation for MixpanelDelegate below for more information.
  */
 @property (atomic, readonly, strong) MixpanelPeople *people;
 
 /*!
- @property
-
- @abstract
  The distinct ID of the current user.
 
- @discussion
- A distinct ID is a string that uniquely identifies one of your users.
- Typically, this is the user ID from your database. By default, we'll use a
- hash of the MAC address of the device. To change the current distinct ID,
- use the <code>identify:</code> method.
+ A distinct ID is a string that uniquely identifies one of your users. By default,
+ we'll use the device's advertisingIdentifier UUIDString, if that is not available
+ we'll use the device's identifierForVendor UUIDString, and finally if that
+ is not available we will generate a new random UUIDString. To change the
+ current distinct ID, use the <code>identify:</code> method.
  */
 @property (atomic, readonly, copy) NSString *distinctId;
 
 /*!
- @property
+ The default anonymous Id / distinct Id  given to the events before identify.
 
- @abstract
- Current user's name in Mixpanel Streams.
+ A default distinct ID is a string that uniquely identifies the anonymous activity.
+ By default, we'll use the device's advertisingIdentifier UUIDString, if that is not
+ available we'll use the device's identifierForVendor UUIDString, and finally if that
+ is not available we will generate a new random UUIDString.
  */
-@property (atomic, copy) NSString *nameTag;
+@property (atomic, readonly, copy) NSString *anonymousId;
 
 /*!
- @property
+  The user ID with which <code>identify:</code> is called with.
 
- @abstract
+  This is null until <code>identify:</code> is called and is set to the id
+  with which identify is called with.
+ */
+@property (atomic, readonly, copy) NSString *userId;
+
+/*!
+ The alias of the current user.
+
+ An alias is another string that uniquely identifies one of your users. Typically,
+ this is the user ID from your database. By using an alias you can link pre- and
+ post-sign up activity as well as cross-platform activity under one distinct ID.
+ To set the alias use the <code>createAlias:forDistinctID:</code> method.
+ */
+@property (atomic, readonly, copy) NSString *alias;
+
+/*!
+ A flag which says if a distinctId is already in peristence from old sdk
+  Defaults to NO.
+ */
+@property (atomic) BOOL hadPersistedDistinctId;
+
+/*!
  The base URL used for Mixpanel API requests.
 
- @discussion
  Useful if you need to proxy Mixpanel requests. Defaults to
  https://api.mixpanel.com.
  */
-@property (atomic, copy) NSString *serverURL;
+@property (nonatomic, copy) NSString *serverURL;
 
 /*!
- @property
-
- @abstract
  Flush timer's interval.
 
- @discussion
  Setting a flush interval of 0 will turn off the flush timer.
  */
 @property (atomic) NSUInteger flushInterval;
 
 /*!
- @property
- 
- @abstract
- Controls whether to automatically send the client IP Address as part of
- event tracking. With an IP address, geo-location is possible down to neighborhoods
- within a city, although the Mixpanel Dashboard will just show you city level location
- specificity. For privacy reasons, you may be in a situation where you need to forego
- effectively having access to such granular location information via the IP Address.
- 
- @discussion
- Defaults to YES.
- */
-@property (atomic) BOOL useIPAddressForGeoLocation;
-
-/*!
- @property
-
- @abstract
  Control whether the library should flush data to Mixpanel when the app
  enters the background.
 
- @discussion
  Defaults to YES. Only affects apps targeted at iOS 4.0, when background
  task support was introduced, and later.
  */
 @property (atomic) BOOL flushOnBackground;
 
 /*!
- @property
-
- @abstract
  Controls whether to show spinning network activity indicator when flushing
  data to the Mixpanel servers.
 
- @discussion
  Defaults to YES.
  */
-@property (atomic) BOOL showNetworkActivityIndicator;
+@property (atomic) BOOL shouldManageNetworkActivityIndicator;
 
 /*!
- @property
-
- @abstract
- Controls whether to automatically check for surveys for the
- currently identified user when the application becomes active.
-
- @discussion
- Defaults to YES. Will fire a network request on
- <code>applicationDidBecomeActive</code> to retrieve a list of valid surveys
- for the currently identified user.
- */
-@property (atomic) BOOL checkForSurveysOnActive;
-
-/*!
- @property
-
- @abstract
- Controls whether to automatically show a survey for the
- currently identified user when the application becomes active.
-
- @discussion
- Defaults to YES. This will only show a survey if
- <code>checkForSurveysOnActive</code> is also set to YES, and the
- survey check retrieves at least 1 valid survey for the currently
- identified user.
- */
-@property (atomic) BOOL showSurveyOnActive;
-
-/*!
- @property
-
- @abstract
  Controls whether to automatically check for notifications for the
  currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES. Will fire a network request on
  <code>applicationDidBecomeActive</code> to retrieve a list of valid notifications
  for the currently identified user.
@@ -177,13 +163,9 @@
 @property (atomic) BOOL checkForNotificationsOnActive;
 
 /*!
- @property
-
- @abstract
  Controls whether to automatically check for A/B test variants for the
  currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES. Will fire a network request on
  <code>applicationDidBecomeActive</code> to retrieve a list of valid variants
  for the currently identified user.
@@ -191,64 +173,77 @@
 @property (atomic) BOOL checkForVariantsOnActive;
 
 /*!
- @property
-
- @abstract
  Controls whether to automatically check for and show in-app notifications
  for the currently identified user when the application becomes active.
 
- @discussion
  Defaults to YES.
  */
 @property (atomic) BOOL showNotificationOnActive;
 
 /*!
- @property
+ Controls whether to automatically send the client IP Address as part of
+ event tracking. With an IP address, geo-location is possible down to neighborhoods
+ within a city, although the Mixpanel Dashboard will just show you city level location
+ specificity. For privacy reasons, you may be in a situation where you need to forego
+ effectively having access to such granular location information via the IP Address.
 
- @abstract
+ Defaults to YES.
+ */
+@property (atomic) BOOL useIPAddressForGeoLocation;
+
+/*!
+ Controls whether to enable the visual test designer for A/B testing and codeless on mixpanel.com.
+ You will be unable to edit A/B tests and codeless events with this disabled, however *previously*
+ created A/B tests and codeless events will still be delivered.
+
+ Defaults to YES.
+ */
+@property (atomic) BOOL enableVisualABTestAndCodeless;
+
+/*!
+ Controls whether to enable the run time debug logging at all levels. Note that the
+ Mixpanel SDK uses Apple System Logging to forward log messages to `STDERR`, this also
+ means that mixpanel logs are segmented by log level. Settings this to `YES` will enable
+ Mixpanel logging at the following levels:
+
+   * Error - Something has failed
+   * Warning - Something is amiss and might fail if not corrected
+   * Info - The lowest priority that is normally logged, purely informational in nature
+   * Debug - Information useful only to developers, and normally not logged.
+
+
+ Defaults to NO.
+ */
+@property (atomic) BOOL enableLogging;
+
+/*!
  Determines the time, in seconds, that a mini notification will remain on
  the screen before automatically hiding itself.
 
- @discussion
  Defaults to 6.0.
  */
 @property (atomic) CGFloat miniNotificationPresentationTime;
 
+#if !MIXPANEL_NO_AUTOMATIC_EVENTS_SUPPORT
 /*!
- @property
+ The minimum session duration (ms) that is tracked in automatic events.
 
- @abstract
- If set, determines the background color of mini notifications.
-
- @discussion
- If this isn't set, we default to either the color of the UINavigationBar of the top
- UINavigationController that is showing when the notification is presented, the
- UINavigationBar default color for the app or the UITabBar default color.
- */
-@property (atomic) UIColor* miniNotificationBackgroundColor;
-
-/*!
-  @property
-
-  The minimum session duration (ms) that is tracked in automatic events.
+ The default value is 10000 (10 seconds).
  */
 @property (atomic) UInt64 minimumSessionDuration;
 
 /*!
-  @property
+ The maximum session duration (ms) that is tracked in automatic events.
 
-  The maximum session duration (ms) that is tracked in automatic events.
+ The default value is UINT64_MAX (no maximum session duration).
  */
 @property (atomic) UInt64 maximumSessionDuration;
+#endif
 
 /*!
- @property
-
- @abstract
  The a MixpanelDelegate object that can be used to assert fine-grain control
  over Mixpanel network activity.
 
- @discussion
  Using a delegate is optional. See the documentation for MixpanelDelegate
  below for more information.
  */
@@ -257,17 +252,12 @@
 #pragma mark Tracking
 
 /*!
- @method
+ Returns (and creates, if needed) a singleton instance of the API.
 
- @abstract
- Initializes and returns a singleton instance of the API.
-
- @discussion
- If you are only going to send data to a single Mixpanel project from your app,
- as is the common case, then this is the easiest way to use the API. This
- method will set up a singleton instance of the <code>Mixpanel</code> class for
- you using the given project token. When you want to make calls to Mixpanel
- elsewhere in your code, you can use <code>sharedInstance</code>.
+ This method will return a singleton instance of the <code>Mixpanel</code> class for
+ you using the given project token. If an instance does not exist, this method will create
+ one using <code>initWithToken:launchOptions:andFlushInterval:</code>. If you only have one
+ instance in your project, you can use <code>sharedInstance</code> to retrieve it.
 
  <pre>
  [Mixpanel sharedInstance] track:@"Something Happened"]];
@@ -283,13 +273,22 @@
 + (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken;
 
 /*!
- @method
+ Initializes a singleton instance of the API, uses it to set whether or not to opt out tracking for
+ GDPR compliance, and then returns it.
 
- @abstract
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the optOutTrackingByDefault parameter, Mixpanel tracking can be opted out by default.
+
+ @param apiToken        your project token
+ @param optOutTrackingByDefault  whether or not to be opted out from tracking by default
+
+ */
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken optOutTrackingByDefault:(BOOL)optOutTrackingByDefault;
+
+/*!
  Initializes a singleton instance of the API, uses it to track launchOptions information,
  and then returns it.
 
- @discussion
  This is the preferred method for creating a sharedInstance with a mixpanel
  like above. With the launchOptions parameter, Mixpanel can track referral
  information created by push notifications.
@@ -298,45 +297,104 @@
  @param launchOptions   your application delegate's launchOptions
 
  */
-+ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions;
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions;
 
 /*!
- @method
+ Initializes a singleton instance of the API, uses it to track launchOptions information,
+ and then returns it.
 
- @abstract
- Returns the previously instantiated singleton instance of the API.
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the trackCrashes and automaticPushTracking parameter, Mixpanel can track crashes and automatic push.
 
- @discussion
- The API must be initialized with <code>sharedInstanceWithToken:</code> before
- calling this class method.
+ @param apiToken        your project token
+ @param launchOptions   your application delegate's launchOptions
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
  */
-+ (Mixpanel *)sharedInstance;
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking;
 
 /*!
- @method
+ Initializes a singleton instance of the API, uses it to track launchOptions information,
+ and then returns it.
 
- @abstract
+ This is the preferred method for creating a sharedInstance with a mixpanel
+ like above. With the optOutTrackingByDefault parameter, Mixpanel tracking can be opted out by default.
+
+ @param apiToken        your project token
+ @param launchOptions   your application delegate's launchOptions
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
+ @param optOutTrackingByDefault  whether or not to be opted out from tracking by default
+ */
++ (Mixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(nullable NSDictionary *)launchOptions trackCrashes:(BOOL)trackCrashes automaticPushTracking:(BOOL)automaticPushTracking optOutTrackingByDefault:(BOOL)optOutTrackingByDefault;
+
+/*!
+ Returns a previously instantiated singleton instance of the API.
+
+ The API must be initialized with <code>sharedInstanceWithToken:</code> or
+ <code>initWithToken:launchOptions:andFlushInterval</code> before calling this class method.
+ This method will return <code>nil</code> if there are no instances created. If there is more than
+ one instace, it will return the first one that was created by using <code>sharedInstanceWithToken:</code>
+ or <code>initWithToken:launchOptions:andFlushInterval:</code>.
+ */
++ (nullable Mixpanel *)sharedInstance;
+
+/*!
+ Initializes an instance of the API with the given project token. This also sets
+ it as a shared instance so you can use <code>sharedInstance</code> or
+ <code>sharedInstanceWithToken:</code> to retrieve this object later.
+
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
+
+ @param apiToken        your project token
+ @param launchOptions   optional app delegate launchOptions
+ @param flushInterval   interval to run background flushing
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+                        issues with your crash reporting for either signals or exceptions
+ */
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes;
+
+/*!
+ Initializes an instance of the API with the given project token. This also sets
+ it as a shared instance so you can use <code>sharedInstance</code> or
+ <code>sharedInstanceWithToken:</code> to retrieve this object later.
+
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
+
+ @param apiToken        your project token
+ @param launchOptions   optional app delegate launchOptions
+ @param flushInterval   interval to run background flushing
+ @param trackCrashes    whether or not to track crashes in Mixpanel. may want to disable if you're seeing
+ issues with your crash reporting for either signals or exceptions
+ @param automaticPushTracking    whether or not to automatically track pushes sent from Mixpanel
+ */
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+                flushInterval:(NSUInteger)flushInterval
+                 trackCrashes:(BOOL)trackCrashes
+        automaticPushTracking:(BOOL)automaticPushTracking;
+
+/*!
  Initializes an instance of the API with the given project token.
 
- @discussion
- Returns the a new API object. This allows you to create more than one instance
- of the API object, which is convenient if you'd like to send data to more than
- one Mixpanel project from a single app. If you only need to send data to one
- project, consider using <code>sharedInstanceWithToken:</code>.
+ Creates and initializes a new API object. See also <code>sharedInstanceWithToken:</code>.
 
  @param apiToken        your project token
  @param launchOptions   optional app delegate launchOptions
  @param flushInterval   interval to run background flushing
  */
-- (instancetype)initWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions andFlushInterval:(NSUInteger)flushInterval;
+- (instancetype)initWithToken:(NSString *)apiToken
+                launchOptions:(nullable NSDictionary *)launchOptions
+             andFlushInterval:(NSUInteger)flushInterval;
 
 /*!
- @method
-
- @abstract
  Initializes an instance of the API with the given project token.
 
- @discussion
  Supports for the old initWithToken method format but really just passes
  launchOptions to the above method as nil.
 
@@ -346,12 +404,8 @@
 - (instancetype)initWithToken:(NSString *)apiToken andFlushInterval:(NSUInteger)flushInterval;
 
 /*!
- @property
-
- @abstract
  Sets the distinct ID of the current user.
 
- @discussion
  As of version 2.3.1, Mixpanel will choose a default distinct ID based on
  whether you are using the AdSupport.framework or not.
 
@@ -369,7 +423,9 @@
  Mixpanel will use the IFV as the default distinct ID.
 
  If we are unable to get an IFA or IFV, we will fall back to generating a
- random persistent UUID.
+ random persistent UUID. If you want to always use a random persistent UUID
+ you can define the <code>MIXPANEL_RANDOM_DISTINCT_ID</code> preprocessor flag
+ in your build settings.
 
  For tracking events, you do not need to call <code>identify:</code> if you
  want to use the default.  However, <b>Mixpanel People always requires an
@@ -387,9 +443,82 @@
 - (void)identify:(NSString *)distinctId;
 
 /*!
- @method
+ Sets the distinct ID of the current user. With the option of only updating the
+ distinct ID value and not the Mixpanel People distinct ID.
 
- @abstract
+ This method is not intended to be used unless you wish to prevent updating the Mixpanel
+ People distinct ID value by passing a value of NO to the usePeople param. This can be
+ useful if the user wishes to prevent People updates from being sent until the identify
+ method is called.
+
+ @param distinctId string that uniquely identifies the current user
+ @param usePeople bool controls whether or not to set the people distinctId to the event distinctId
+ */
+- (void)identify:(NSString *)distinctId usePeople:(BOOL)usePeople;
+
+/*!
+ Add a group to this user's membership for a particular group key.
+ The groupKey must be an NSString. The groupID should be a legal MixpanelType value.
+ 
+ @param groupKey        the group key
+ @param groupID         the group ID
+ */
+- (void)addGroup:(NSString *)groupKey groupID:(id<MixpanelType>)groupID;
+
+/*!
+ Remove a group from this user's membership for a particular group key.
+ The groupKey must be an NSString. The groupID should be a legal MixpanelType value.
+ 
+ @param groupKey        the group key
+ @param groupID         the group ID
+ */
+- (void)removeGroup:(NSString *)groupKey groupID:(id<MixpanelType>)groupID;
+
+/*!
+ Set the group to which the user belongs.
+ The groupKey must be an NSString. The groupID should be an array
+ of MixpanelTypes.
+ 
+ @param groupKey        the group key
+ @param groupIDs        the group IDs
+ */
+- (void)setGroup:(NSString *)groupKey groupIDs:(NSArray<id<MixpanelType>> *)groupIDs;
+
+/*!
+ Convenience method to set a single group ID for the current user.
+ 
+ @param groupKey        the group key
+ @param groupID         the group ID
+ */
+- (void)setGroup:(NSString *)groupKey groupID:(id<MixpanelType>)groupID;
+
+/*!
+ Tracks an event with specific groups.
+ 
+ Similar to track(), the data will also be sent to the specific group
+ datasets. Group key/value pairs are upserted into the property map
+ before tracking.
+ The keys in groups must be NSString objects. values can be any legal
+ MixpanelType objects. If the event is being timed, the timer will
+ stop and be added as a property.
+ 
+ @param event               event name
+ @param properties          properties dictionary
+ @param groups              groups dictionary, which contains key-value pairs
+ for this event
+ */
+- (void)trackWithGroups:(NSString *)event properties:(NSDictionary *)properties groups:(NSDictionary *)groups;
+
+/*!
+ Get a MixpanelGroup identifier from groupKey and groupID.
+ The groupKey must be an NSString. The groupID should be a legal MixpanelType value.
+ 
+ @param groupKey    the group key
+ @param groupID     the group ID
+ */
+- (MixpanelGroup *)getGroup:(NSString *)groupKey groupID:(id<MixpanelType>)groupID;
+
+/*!
  Tracks an event.
 
  @param event           event name
@@ -397,12 +526,8 @@
 - (void)track:(NSString *)event;
 
 /*!
- @method
-
- @abstract
  Tracks an event with properties.
 
- @discussion
  Properties will allow you to segment your events in your Mixpanel reports.
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
@@ -413,33 +538,11 @@
  @param event           event name
  @param properties      properties dictionary
  */
-- (void)track:(NSString *)event properties:(NSDictionary *)properties;
-
-
-/*!
- @method
-
- @abstract
- Track a push notification using its payload sent from Mixpanel.
-
- @discussion
- To simplify user interaction tracking and a/b testing, Mixpanel
- automatically sends IDs for the relevant notification and a/b variants
- of each push. This method parses the standard payload and queues a
- track call using this information.
-
- @param userInfo         remote notification payload dictionary
- */
-- (void)trackPushNotification:(NSDictionary *)userInfo;
-
+- (void)track:(NSString *)event properties:(nullable NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties, overwriting ones that have already been set.
 
- @discussion
  Super properties, once registered, are automatically sent as properties for
  all event tracking calls. They save you having to maintain and add a common
  set of properties to your events. Property keys must be <code>NSString</code>
@@ -452,13 +555,9 @@
 - (void)registerSuperProperties:(NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties without overwriting ones that have already been
  set.
 
- @discussion
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
  <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
@@ -469,13 +568,9 @@
 - (void)registerSuperPropertiesOnce:(NSDictionary *)properties;
 
 /*!
- @method
-
- @abstract
  Registers super properties without overwriting ones that have already been set
  unless the existing value is equal to defaultValue.
 
- @discussion
  Property keys must be <code>NSString</code> objects and values must be
  <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
  <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
@@ -484,15 +579,11 @@
  @param properties      properties dictionary
  @param defaultValue    overwrite existing properties that have this value
  */
-- (void)registerSuperPropertiesOnce:(NSDictionary *)properties defaultValue:(id)defaultValue;
+- (void)registerSuperPropertiesOnce:(NSDictionary *)properties defaultValue:(nullable id)defaultValue;
 
 /*!
- @method
-
- @abstract
  Removes a previously registered super property.
 
- @discussion
  As an alternative to clearing all properties, unregistering specific super
  properties prevents them from being recorded on future events. This operation
  does not affect the value of other super properties. Any property name that is
@@ -507,29 +598,19 @@
 - (void)unregisterSuperProperty:(NSString *)propertyName;
 
 /*!
- @method
-
- @abstract
  Clears all currently set super properties.
  */
 - (void)clearSuperProperties;
 
 /*!
- @method
-
- @abstract
  Returns the currently set super properties.
  */
 - (NSDictionary *)currentSuperProperties;
 
 /*!
- @method
-
- @abstract
  Starts a timer that will be stopped and added as a property when a
  corresponding event is tracked.
 
- @discussion
  This method is intended to be used in advance of events that have
  a duration. For example, if a developer were to track an "Image Upload" event
  she might want to also know how long the upload took. Calling this method
@@ -554,28 +635,25 @@
 - (void)timeEvent:(NSString *)event;
 
 /*!
- @method
+ Retrieves the time elapsed for the named event since <code>timeEvent:</code> was called.
 
- @abstract
+ @param event   the name of the event to be tracked that was passed to <code>timeEvent:</code>
+ */
+- (double)eventElapsedTime:(NSString *)event;
+
+/*!
  Clears all current event timers.
  */
 - (void)clearTimedEvents;
 
 /*!
- @method
-
- @abstract
  Clears all stored properties and distinct IDs. Useful if your app's user logs out.
  */
 - (void)reset;
 
 /*!
- @method
-
- @abstract
  Uploads queued data to the Mixpanel server.
 
- @discussion
  By default, queued data is flushed to the Mixpanel servers every minute (the
  default for <code>flushInterval</code>), and on background (since
  <code>flushOnBackground</code> is on by default). You only need to call this
@@ -584,12 +662,8 @@
 - (void)flush;
 
 /*!
- @method
-
- @abstract
  Calls flush, then optionally archives and calls a handler when finished.
 
- @discussion
  When calling <code>flush</code> manually, it is sometimes important to verify
  that the flush has finished before further action is taken. This is
  especially important when the app is in the background and could be suspended
@@ -597,17 +671,15 @@
  <code>application:didReceiveRemoteNotification:fetchCompletionHandler:</code>
  are called when an app is brought to the background and require a handler to
  be called when it finishes.
+
+ @param handler     completion handler to be called after flush completes
  */
-- (void)flushWithCompletion:(void (^)())handler;
+- (void)flushWithCompletion:(nullable void (^)(void))handler;
 
 /*!
- @method
-
- @abstract
  Writes current project info, including distinct ID, super properties and pending event
  and People record queues to disk.
 
- @discussion
  This state will be recovered when the app is launched again if the Mixpanel
  library is initialized with the same project token. <b>You do not need to call
  this method</b>. The library listens for app state changes and handles
@@ -617,18 +689,13 @@
 - (void)archive;
 
 /*!
- @method
-
- @abstract
  Creates a distinct_id alias from alias to original id.
 
- @discussion
  This method is used to map an identifier called an alias to the existing Mixpanel
  distinct id. This causes all events and people requests sent with the alias to be
  mapped back to the original distinct id. The recommended usage pattern is to call
- both createAlias: and identify: when the user signs up, and only identify: (with
- their new user ID) when they log in. This will keep your signup funnels working
- correctly.
+ createAlias: and then identify: (with their new user ID) when they log in the next time.
+ This will keep your signup funnels working correctly.
 
  <pre>
  // This makes the current ID (an auto-generated GUID)
@@ -646,59 +713,102 @@
  */
 - (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID;
 
+/*!
+ Creates a distinct_id alias from alias to original id.
+
+ This method is not intended to be used unless you wish to prevent updating the Mixpanel
+ People distinct ID value by passing a value of NO to the usePeople param. This can be
+ useful if the user wishes to prevent People updates from being sent until the identify
+ method is called.
+
+ @param alias         the new distinct_id that should represent original
+ @param distinctID     the old distinct_id that alias will be mapped to
+ @param usePeople bool controls whether or not to set the people distinctId to the event distinctId
+ */
+- (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID usePeople:(BOOL)usePeople;
+
+/*!
+ Returns the Mixpanel library version number as a string, e.g. "3.2.3".
+ */
 - (NSString *)libVersion;
 
+/*!
+ Opt out tracking.
 
-#if !defined(MIXPANEL_APP_EXTENSION)
-#pragma mark - Mixpanel Surveys
+ This method is used to opt out tracking. This causes all events and people request no longer
+ to be sent back to the Mixpanel server.
+ */
+- (void)optOutTracking;
 
 /*!
- @method
+ Opt in tracking.
 
- @abstract
- Shows the survey with the given name.
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
 
- @discussion
- This method allows you to explicitly show a named survey at the time of your choosing.
-
+ This method will internally track an opt in event to your project. If you want to identify the opt-in
+ event and/or pass properties to the event, See also <code>optInTrackingForDistinctId:</code> and
+ <code>optInTrackingForDistinctId:withEventProperties:</code>.
  */
-- (void)showSurveyWithID:(NSUInteger)ID;
+- (void)optInTracking;
 
 /*!
- @method
+ Opt in tracking.
 
- @abstract
- Show a survey if one is available.
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
 
- @discussion
- This method allows you to display the first available survey targeted to the currently
- identified user at the time of your choosing. You would typically pair this with
- setting <code>showSurveyOnActive = NO;</code> so that the survey won't show automatically.
+ This method will internally track an opt in event to your project. If you want to pass properties to the event, see also
+ <code>optInTrackingForDistinctId:withEventProperties:</code>.
 
+ @param distinctID     optional string to use as the distinct ID for events. This will call <code>identify:</code>.
+ If you use people profiles make sure you manually call <code>identify:</code> after this method.
  */
-- (void)showSurvey;
+- (void)optInTrackingForDistinctID:(nullable NSString *)distinctID;
 
+/*!
+ Opt in tracking.
+
+ Use this method to opt in an already opted out user from tracking. People updates and track calls will be
+ sent to Mixpanel after using this method.
+
+ This method will internally track an opt in event to your project.See also <code>optInTracking</code> or
+ <code>optInTrackingForDistinctId:</code>.
+
+ @param distinctID     optional string to use as the distinct ID for events. This will call <code>identify:</code>.
+ If you use people profiles make sure you manually call <code>identify:</code> after this method.
+ @param properties     optional properties dictionary that could be passed to add properties to the opt-in event that is sent to
+ Mixpanel.
+ */
+- (void)optInTrackingForDistinctID:(nullable NSString *)distinctID withEventProperties:(nullable NSDictionary *)properties;
+
+/*!
+ Returns YES if the current user has opted out tracking, NO if the current user has opted in tracking.
+ */
+- (BOOL)hasOptedOutTracking;
+
+/*!
+ Returns the Mixpanel library version number as a string, e.g. "3.2.3".
+ */
++ (NSString *)libVersion;
+
+
+#if !MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 #pragma mark - Mixpanel Notifications
 
 /*!
- @method
-
- @abstract
  Shows the notification of the given id.
 
- @discussion
  You do not need to call this method on the main thread.
+
+ @param ID      notification id
  */
 - (void)showNotificationWithID:(NSUInteger)ID;
 
 
 /*!
- @method
-
- @abstract
  Shows a notification with the given type if one is available.
 
- @discussion
  You do not need to call this method on the main thread.
 
  @param type The type of notification to show, either @"mini", or @"takeover"
@@ -706,12 +816,8 @@
 - (void)showNotificationWithType:(NSString *)type;
 
 /*!
- @method
-
- @abstract
  Shows a notification if one is available.
 
- @discussion
  You do not need to call this method on the main thread.
  */
 - (void)showNotification;
@@ -719,12 +825,8 @@
 #pragma mark - Mixpanel A/B Testing
 
 /*!
- @method
-
- @abstract
  Join any experiments (A/B tests) that are available for the current user.
 
- @discussion
  Mixpanel will check for A/B tests automatically when your app enters
  the foreground. Call this method if you would like to to check for,
  and join, any experiments are newly available for the current user.
@@ -734,324 +836,43 @@
 - (void)joinExperiments;
 
 /*!
- @method
-
- @abstract
  Join any experiments (A/B tests) that are available for the current user.
 
- @discussion
  Same as joinExperiments but will fire the given callback after all experiments
  have been loaded and applied.
+
+ @param experimentsLoadedCallback       callback to be called after experiments
+                                        joined and applied
  */
-- (void)joinExperimentsWithCallback:(void(^)())experimentsLoadedCallback;
+- (void)joinExperimentsWithCallback:(nullable void (^)(void))experimentsLoadedCallback;
 
-#endif
+#endif // MIXPANEL_NO_NOTIFICATION_AB_TEST_SUPPORT
 
-@end
-
+#pragma mark - Deprecated
 /*!
- @class
- Mixpanel People API.
-
- @abstract
- Access to the Mixpanel People API, available as a property on the main
- Mixpanel API.
-
- @discussion
- <b>You should not instantiate this object yourself.</b> An instance of it will
- be available as a property of the main Mixpanel object. Calls to Mixpanel
- People methods will look like this:
-
- <pre>
- [mixpanel.people increment:@"App Opens" by:1];
- </pre>
-
- Please note that the core <code>Mixpanel</code> and
- <code>MixpanelPeople</code> classes share the <code>identify:</code> method.
- The <code>Mixpanel</code> <code>identify:</code> affects the
- <code>distinct_id</code> property of events sent by <code>track:</code> and
- <code>track:properties:</code> and determines which Mixpanel People user
- record will be updated by <code>set:</code>, <code>increment:</code> and other
- <code>MixpanelPeople</code> methods.
-
- <b>If you are going to set your own distinct IDs for core Mixpanel event
- tracking, make sure to use the same distinct IDs when using Mixpanel
- People</b>.
+ Current user's name in Mixpanel Streams.
  */
-@interface MixpanelPeople : NSObject
-/*!
- @property
-
- @abstract
- controls the $ignore_time property in any subsequent MixpanelPeople operation.
-
- If the $ignore_time property is present and true in your request,
- Mixpanel will not automatically update the "Last Seen" property of the profile.
- Otherwise, Mixpanel will add a "Last Seen" property associated with the
- current time for all $set, $append, and $add operations
-
- @discussion
- Defaults to NO.
- */
-@property (atomic) BOOL ignoreTime;
-
-/*!
- @method
-
- @abstract
- Register the given device to receive push notifications.
-
- @discussion
- This will associate the device token with the current user in Mixpanel People,
- which will allow you to send push notifications to the user from the Mixpanel
- People web interface. You should call this method with the <code>NSData</code>
- token passed to
- <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>.
-
- @param deviceToken     device token as returned <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>
- */
-- (void)addPushDeviceToken:(NSData *)deviceToken;
-
-/*!
- @method
-
- @abstract
- Unregister the given device to receive push notifications.
-
- @discussion
- This will unset all of the push tokens saved to this people profile. This is useful
- in conjunction with a call to `reset`, or when a user is logging out.
- */
-- (void)removeAllPushDeviceTokens;
-
-/*!
- @method
-
- @abstract
- Unregister a specific device token from the ability to receive push notifications.
-
- @discussion
- This will remove the provided push token saved to this people profile. This is useful
- in conjunction with a call to `reset`, or when a user is logging out.
- */
-- (void)removePushDeviceToken:(NSData *)deviceToken;
-
-/*!
- @method
-
- @abstract
- Set properties on the current user in Mixpanel People.
-
- @discussion
- The properties will be set on the current user. The keys must be NSString
- objects and the values should be NSString, NSNumber, NSArray, NSDate, or
- NSNull objects. We use an NSAssert to enforce this type requirement. In
- release mode, the assert is stripped out and we will silently convert
- incorrect types to strings using [NSString stringWithFormat:@"%@", value]. You
- can override the default the current project token and distinct ID by
- including the special properties: $token and $distinct_id. If the existing
- user record on the server already has a value for a given property, the old
- value is overwritten. Other existing properties will not be affected.
-
- <pre>
- // applies to both Mixpanel Engagement track: AND Mixpanel People set: and
- // increment: calls
- [mixpanel identify:distinctId];
- </pre>
-
- @param properties       properties dictionary
-
- */
-- (void)set:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Convenience method for setting a single property in Mixpanel People.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param property        property name
- @param object          property value
- */
-- (void)set:(NSString *)property to:(id)object;
-
-/*!
- @method
-
- @abstract
- Set properties on the current user in Mixpanel People, but don't overwrite if
- there is an existing value.
-
- @discussion
- This method is identical to <code>set:</code> except it will only set
- properties that are not already set. It is particularly useful for collecting
- data about the user's initial experience and source, as well as dates
- representing the first time something happened.
-
- @param properties       properties dictionary
-
- */
-- (void)setOnce:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Remove a list of properties and their values from the current user's profile
- in Mixpanel People.
-
- @discussion
- The properties array must ony contain NSString names of properties. For properties
- that don't exist there will be no effect.
-
- @param properties       properties array
-
- */
-- (void)unset:(NSArray *)properties;
-
-/*!
- @method
-
- @abstract
- Increment the given numeric properties by the given values.
-
- @discussion
- Property keys must be NSString names of numeric properties. A property is
- numeric if its current value is a number. If a property does not exist, it
- will be set to the increment amount. Property values must be NSNumber objects.
-
- @param properties      properties dictionary
- */
-- (void)increment:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Convenience method for incrementing a single numeric property by the specified
- amount.
-
- @param property        property name
- @param amount          amount to increment by
- */
-- (void)increment:(NSString *)property by:(NSNumber *)amount;
-
-/*!
- @method
-
- @abstract
- Append values to list properties.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param properties      mapping of list property names to values to append
- */
-- (void)append:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Union list properties.
-
- @discussion
- Property keys must be <code>NSArray</code> objects.
-
- @param properties      mapping of list property names to lists to union
- */
-- (void)union:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Remove list properties.
-
- @discussion
- Property keys must be <code>NSString</code> objects and values must be
- <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
- <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
- <code>NSURL</code> objects.
-
- @param properties      mapping of list property names to values to remove
- */
-- (void)remove:(NSDictionary *)properties;
-
-/*!
- @method
-
- @abstract
- Track money spent by the current user for revenue analytics.
-
- @param amount          amount of revenue received
- */
-- (void)trackCharge:(NSNumber *)amount;
-
-/*!
- @method
-
- @abstract
- Track money spent by the current user for revenue analytics and associate
- properties with the charge.
-
- @discussion
- Charge properties allow you segment on types of revenue. For instance, you
- could record a product ID with each charge so that you could segment on it in
- revenue analytics to see which products are generating the most revenue.
- */
-- (void)trackCharge:(NSNumber *)amount withProperties:(nullable NSDictionary *)properties;
-
-
-/*!
- @method
-
- @abstract
- Delete current user's revenue history.
- */
-- (void)clearCharges;
-
-/*!
- @method
-
- @abstract
- Delete current user's record from Mixpanel People.
- */
-- (void)deleteUser;
+@property (nullable, atomic, copy) NSString *nameTag __deprecated; // Deprecated in v3.0.1
 
 @end
 
 /*!
  @protocol
 
- @abstract
  Delegate protocol for controlling the Mixpanel API's network behavior.
 
- @discussion
  Creating a delegate for the Mixpanel object is entirely optional. It is only
  necessary when you want full control over when data is uploaded to the server,
  beyond simply calling stop: and start: before and after a particular block of
  your code.
  */
+
 @protocol MixpanelDelegate <NSObject>
+
 @optional
-
 /*!
- @method
-
- @abstract
  Asks the delegate if data should be uploaded to the server.
 
- @discussion
  Return YES to upload now, NO to defer until later.
 
  @param mixpanel        Mixpanel API instance
@@ -1059,3 +880,5 @@
 - (BOOL)mixpanelWillFlush:(Mixpanel *)mixpanel;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -423,9 +423,7 @@ extern NSString *const MPNotificationTypeTakeover;
  Mixpanel will use the IFV as the default distinct ID.
 
  If we are unable to get an IFA or IFV, we will fall back to generating a
- random persistent UUID. If you want to always use a random persistent UUID
- you can define the <code>MIXPANEL_RANDOM_DISTINCT_ID</code> preprocessor flag
- in your build settings.
+ random persistent UUID.
 
  For tracking events, you do not need to call <code>identify:</code> if you
  want to use the default.  However, <b>Mixpanel People always requires an

--- a/RNMixpanel/Mixpanel.h
+++ b/RNMixpanel/Mixpanel.h
@@ -201,16 +201,30 @@
 
 /*!
  @property
- 
+
  @abstract
  If set, determines the background color of mini notifications.
 
  @discussion
- If this isn't set, we default to either the color of the UINavigationBar of the top 
- UINavigationController that is showing when the notification is presented, the 
+ If this isn't set, we default to either the color of the UINavigationBar of the top
+ UINavigationController that is showing when the notification is presented, the
  UINavigationBar default color for the app or the UITabBar default color.
  */
 @property (atomic) UIColor* miniNotificationBackgroundColor;
+
+/*!
+  @property
+
+  The minimum session duration (ms) that is tracked in automatic events.
+ */
+@property (atomic) UInt64 minimumSessionDuration;
+
+/*!
+  @property
+
+  The maximum session duration (ms) that is tracked in automatic events.
+ */
+@property (atomic) UInt64 maximumSessionDuration;
 
 /*!
  @property
@@ -556,10 +570,10 @@
 
 /*!
  @method
- 
+
  @abstract
  Calls flush, then optionally archives and calls a handler when finished.
- 
+
  @discussion
  When calling <code>flush</code> manually, it is sometimes important to verify
  that the flush has finished before further action is taken. This is

--- a/RNMixpanel/MixpanelPeople.h
+++ b/RNMixpanel/MixpanelPeople.h
@@ -1,0 +1,229 @@
+//
+//  MixpanelPeople.h
+//  Mixpanel
+//
+//  Created by Sam Green on 6/16/16.
+//  Copyright © 2016 Mixpanel. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*!
+ Mixpanel People API.
+
+ Access to the Mixpanel People API, available as a property on the main
+ Mixpanel API.
+
+ <b>You should not instantiate this object yourself.</b> An instance of it will
+ be available as a property of the main Mixpanel object. Calls to Mixpanel
+ People methods will look like this:
+
+ <pre>
+ [mixpanel.people increment:@"App Opens" by:[NSNumber numberWithInt:1]];
+ </pre>
+
+ Please note that the core <code>Mixpanel</code> and
+ <code>MixpanelPeople</code> classes share the <code>identify:</code> method.
+ The <code>Mixpanel</code> <code>identify:</code> affects the
+ <code>distinct_id</code> property of events sent by <code>track:</code> and
+ <code>track:properties:</code> and determines which Mixpanel People user
+ record will be updated by <code>set:</code>, <code>increment:</code> and other
+ <code>MixpanelPeople</code> methods.
+
+ <b>If you are going to set your own distinct IDs for core Mixpanel event
+ tracking, make sure to use the same distinct IDs when using Mixpanel
+ People</b>.
+ */
+@interface MixpanelPeople : NSObject
+/*!
+ controls the $ignore_time property in any subsequent MixpanelPeople operation.
+
+ If the $ignore_time property is present and true in your request,
+ Mixpanel will not automatically update the "Last Seen" property of the profile.
+ Otherwise, Mixpanel will add a "Last Seen" property associated with the
+ current time for all $set, $append, and $add operations
+
+ Defaults to NO.
+ */
+@property (atomic) BOOL ignoreTime;
+
+/*!
+ Register the given device to receive push notifications.
+
+ This will associate the device token with the current user in Mixpanel People,
+ which will allow you to send push notifications to the user from the Mixpanel
+ People web interface. You should call this method with the <code>NSData</code>
+ token passed to
+ <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>.
+
+ @param deviceToken     device token as returned <code>application:didRegisterForRemoteNotificationsWithDeviceToken:</code>
+ */
+- (void)addPushDeviceToken:(NSData *)deviceToken;
+
+/*!
+ Unregister the given device to receive push notifications.
+
+ This will unset all of the push tokens saved to this people profile. This is useful
+ in conjunction with a call to `reset`, or when a user is logging out.
+ */
+- (void)removeAllPushDeviceTokens;
+
+/*!
+ Unregister a specific device token from the ability to receive push notifications.
+
+ This will remove the provided push token saved to this people profile. This is useful
+ in conjunction with a call to `reset`, or when a user is logging out.
+
+ @param deviceToken     device token to be unregistered
+ */
+- (void)removePushDeviceToken:(NSData *)deviceToken;
+
+/*!
+ Set properties on the current user in Mixpanel People.
+
+ The properties will be set on the current user. The keys must be NSString
+ objects and the values should be NSString, NSNumber, NSArray, NSDate, or
+ NSNull objects. We use an NSAssert to enforce this type requirement. In
+ release mode, the assert is stripped out and we will silently convert
+ incorrect types to strings using [NSString stringWithFormat:@"%@", value]. You
+ can override the default the current project token and distinct ID by
+ including the special properties: $token and $distinct_id. If the existing
+ user record on the server already has a value for a given property, the old
+ value is overwritten. Other existing properties will not be affected.
+
+ <pre>
+ // applies to both Mixpanel Engagement track: AND Mixpanel People set: and
+ // increment: calls
+ [mixpanel identify:distinctId];
+ </pre>
+
+ @param properties       properties dictionary
+
+ */
+- (void)set:(NSDictionary *)properties;
+
+/*!
+ Convenience method for setting a single property in Mixpanel People.
+
+ Property keys must be <code>NSString</code> objects and values must be
+ <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
+ <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
+ <code>NSURL</code> objects.
+
+ @param property        property name
+ @param object          property value
+ */
+- (void)set:(NSString *)property to:(id)object;
+
+/*!
+ Set properties on the current user in Mixpanel People, but don't overwrite if
+ there is an existing value.
+
+ This method is identical to <code>set:</code> except it will only set
+ properties that are not already set. It is particularly useful for collecting
+ data about the user's initial experience and source, as well as dates
+ representing the first time something happened.
+
+ @param properties       properties dictionary
+
+ */
+- (void)setOnce:(NSDictionary *)properties;
+
+/*!
+ Remove a list of properties and their values from the current user's profile
+ in Mixpanel People.
+
+ The properties array must ony contain NSString names of properties. For properties
+ that don't exist there will be no effect.
+
+ @param properties       properties array
+
+ */
+- (void)unset:(NSArray *)properties;
+
+/*!
+ Increment the given numeric properties by the given values.
+
+ Property keys must be NSString names of numeric properties. A property is
+ numeric if its current value is a number. If a property does not exist, it
+ will be set to the increment amount. Property values must be NSNumber objects.
+
+ @param properties      properties dictionary
+ */
+- (void)increment:(NSDictionary *)properties;
+
+/*!
+ Convenience method for incrementing a single numeric property by the specified
+ amount.
+
+ @param property        property name
+ @param amount          amount to increment by
+ */
+- (void)increment:(NSString *)property by:(NSNumber *)amount;
+
+/*!
+ Append values to list properties.
+
+ Property keys must be <code>NSString</code> objects and values must be
+ <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
+ <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
+ <code>NSURL</code> objects.
+
+ @param properties      mapping of list property names to values to append
+ */
+- (void)append:(NSDictionary *)properties;
+
+/*!
+ Union list properties.
+
+ Property keys must be <code>NSString</code> objects.
+
+ @param properties      mapping of list property names to lists to union
+ */
+- (void)union:(NSDictionary *)properties;
+
+/*!
+ Remove list properties.
+
+ Property keys must be <code>NSString</code> objects and values must be
+ <code>NSString</code>, <code>NSNumber</code>, <code>NSNull</code>,
+ <code>NSArray</code>, <code>NSDictionary</code>, <code>NSDate</code> or
+ <code>NSURL</code> objects.
+
+ @param properties      mapping of list property names to values to remove
+ */
+- (void)remove:(NSDictionary *)properties;
+
+/*!
+ Track money spent by the current user for revenue analytics.
+
+ @param amount          amount of revenue received
+ */
+- (void)trackCharge:(NSNumber *)amount;
+
+/*!
+ Track money spent by the current user for revenue analytics and associate
+ properties with the charge.
+
+ Charge properties allow you segment on types of revenue. For instance, you
+ could record a product ID with each charge so that you could segment on it in
+ revenue analytics to see which products are generating the most revenue.
+ */
+- (void)trackCharge:(NSNumber *)amount withProperties:(nullable NSDictionary *)properties;
+
+
+/*!
+ Delete current user's revenue history.
+ */
+- (void)clearCharges;
+
+/*!
+ Delete current user's record from Mixpanel People.
+ */
+- (void)deleteUser;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/RNMixpanel/RNMixpanel.h
+++ b/RNMixpanel/RNMixpanel.h
@@ -10,6 +10,8 @@
 
 @interface RNMixpanel : NSObject<RCTBridgeModule>
 
-+ (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken launchOptions:(NSDictionary *)launchOptions;
++ (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken
+                optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
+                          launchOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/RNMixpanel/RNMixpanel.h
+++ b/RNMixpanel/RNMixpanel.h
@@ -12,6 +12,8 @@
 
 + (RNMixpanel *)sharedInstanceWithToken:(NSString *)apiToken
                 optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
+                           trackCrashes:(BOOL)trackCrashes
+                  automaticPushTracking:(BOOL)automaticPushTracking
                           launchOptions:(NSDictionary *)launchOptions;
 
 @end

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
                                                  launchOptions:launchOptions
                                                   trackCrashes:trackCrashes
                                          automaticPushTracking:automaticPushTracking
-                                       optOutTrackingByDefault:optOutTrackingByDefault;];
+                                       optOutTrackingByDefault:optOutTrackingByDefault];
 
         // copy instances and add the new instance.  then reassign instances
         NSMutableDictionary *newInstances = [NSMutableDictionary dictionaryWithDictionary:instances];

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -47,7 +47,6 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
 }
 
 // setAppSessionProperties iOS
-// setAppSessionProperties iOS
 RCT_EXPORT_METHOD(setAppSessionPropertiesIOS:(NSDictionary *)properties) {
     if ([properties objectForKey:@"minimumSessionDuration"]) {
         NSNumber *minimumSessionDuration = properties[@"minimumSessionDuration"];
@@ -298,6 +297,14 @@ RCT_EXPORT_METHOD(reset:(NSString *)apiToken
     [[self getInstance:apiToken] reset];
     NSString *uuid = [[NSUUID UUID] UUIDString];
     [[self getInstance:apiToken] identify:uuid];
+    resolve(nil);
+}
+
+// showNotification
+RCT_EXPORT_METHOD(showNotification:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[self getInstance:apiToken] showNotification];
     resolve(nil);
 }
 

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -47,17 +47,18 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
 }
 
 // setAppSessionProperties iOS
+// setAppSessionProperties iOS
 RCT_EXPORT_METHOD(setAppSessionPropertiesIOS:(NSDictionary *)properties) {
     if ([properties objectForKey:@"minimumSessionDuration"]) {
         NSNumber *minimumSessionDuration = properties[@"minimumSessionDuration"];
         long long int intValue = [minimumSessionDuration longLongValue];
-        mixpanel.minimumSessionDuration = intValue;
+        [Mixpanel sharedInstance].minimumSessionDuration = intValue;
     }
 
     if ([properties objectForKey:@"maximumSessionDuration"]) {
         NSNumber *maximumSessionDuration = properties[@"maximumSessionDuration"];
         long long int intValue = [maximumSessionDuration longLongValue];
-        mixpanel.maximumSessionDuration = intValue;
+        [Mixpanel sharedInstance].maximumSessionDuration = intValue;
     }
 }
 

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -29,6 +29,7 @@ RCT_EXPORT_MODULE(RNMixpanel)
 
 // sharedInstanceWithToken
 RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
+                  optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     @synchronized(self) {
@@ -36,7 +37,10 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
             resolve(nil);
             return;
         }
-        Mixpanel *instance = [Mixpanel sharedInstanceWithToken:apiToken];
+
+        Mixpanel *instance = [Mixpanel sharedInstanceWithToken:apiToken
+                                       optOutTrackingByDefault:optOutTrackingByDefault];
+
         // copy instances and add the new instance.  then reassign instances
         NSMutableDictionary *newInstances = [NSMutableDictionary dictionaryWithDictionary:instances];
         [newInstances setObject:instance forKey:apiToken];
@@ -306,6 +310,21 @@ RCT_EXPORT_METHOD(showNotification:(NSString *)apiToken
                   reject:(RCTPromiseRejectBlock)reject) {
     [[self getInstance:apiToken] showNotification];
     resolve(nil);
+}
+
+// Opt in/out tracking
+RCT_EXPORT_METHOD(optOutTracking:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[self getInstance:apiToken] optOutTracking];
+    resolve(nil);;
+}
+
+RCT_EXPORT_METHOD(optInTracking:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[self getInstance:apiToken] optInTracking];
+    resolve(nil);;
 }
 
 @end

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -280,6 +280,17 @@ RCT_EXPORT_METHOD(union:(NSString *)name
     resolve(nil);
 }
 
+// People append
+RCT_EXPORT_METHOD(append:(NSString *)name
+                  properties:(NSArray *)properties
+                  apiToken:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys: properties, name, nil];
+    [[self getInstance:apiToken].people append:dict];
+    resolve(nil);
+}
+
 // reset
 RCT_EXPORT_METHOD(reset:(NSString *)apiToken
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -86,6 +86,14 @@ RCT_EXPORT_METHOD(track:(NSString *)event
     resolve(nil);
 }
 
+// disable ip address geolocalization
+RCT_EXPORT_METHOD(disableIpAddressGeolocalization:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self getInstance:apiToken].useIPAddressForGeoLocation = NO;
+    resolve(nil);
+}
+
 // track with properties
 RCT_EXPORT_METHOD(trackWithProperties:(NSString *)event
                   properties:(NSDictionary *)properties

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -250,6 +250,17 @@ RCT_EXPORT_METHOD(addPushDeviceToken:(NSString *)pushDeviceToken
     resolve(nil);
 }
 
+// People union
+RCT_EXPORT_METHOD(union:(NSString *)name
+                  properties:(NSArray *)properties
+                  apiToken:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys: properties, name, nil];
+    [[self getInstance:apiToken].people union:dict];
+    resolve(nil);
+}
+
 // reset
 RCT_EXPORT_METHOD(reset:(NSString *)apiToken
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -46,6 +46,20 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
     }
 }
 
+// setAppSessionProperties iOS
+RCT_EXPORT_METHOD(setAppSessionPropertiesIOS:(NSDictionary *)properties) {
+    if ([properties objectForKey:@"minimumSessionDuration"]) {
+        NSNumber *minimumSessionDuration = properties[@"minimumSessionDuration"];
+        long long int intValue = [minimumSessionDuration longLongValue];
+        mixpanel.minimumSessionDuration = intValue;
+    }
+
+    if ([properties objectForKey:@"maximumSessionDuration"]) {
+        NSNumber *maximumSessionDuration = properties[@"maximumSessionDuration"];
+        long long int intValue = [maximumSessionDuration longLongValue];
+        mixpanel.maximumSessionDuration = intValue;
+    }
+}
 
 // get distinct id
 RCT_EXPORT_METHOD(getDistinctId:(NSString *)apiToken

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -193,10 +193,22 @@ RCT_EXPORT_METHOD(setOnce:(NSDictionary *)properties
 }
 
 // Remove Person's Push Token (iOS-only)
-RCT_EXPORT_METHOD(removePushDeviceToken:(NSData *)deviceToken
+RCT_EXPORT_METHOD(removePushDeviceToken:(NSString *)pushDeviceToken
                   apiToken:(NSString *)apiToken
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
+
+    NSMutableData *deviceToken = [[NSMutableData alloc] init];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [pushDeviceToken length]/2; i++) {
+        byte_chars[0] = [pushDeviceToken characterAtIndex:i*2];
+        byte_chars[1] = [pushDeviceToken characterAtIndex:i*2+1];
+        whole_byte = strtol(byte_chars, NULL, 16);
+        [deviceToken appendBytes:&whole_byte length:1];
+    }
+
     [[self getInstance:apiToken].people removePushDeviceToken:deviceToken];
     resolve(nil);
 }

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -30,6 +30,9 @@ RCT_EXPORT_MODULE(RNMixpanel)
 // sharedInstanceWithToken
 RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
                   optOutTrackingByDefault:(BOOL)optOutTrackingByDefault
+                  trackCrashes:(BOOL)trackCrashes
+                  automaticPushTracking:(BOOL)automaticPushTracking
+                  launchOptions:(nullable NSDictionary *)launchOptions
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     @synchronized(self) {
@@ -39,7 +42,10 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
         }
 
         Mixpanel *instance = [Mixpanel sharedInstanceWithToken:apiToken
-                                       optOutTrackingByDefault:optOutTrackingByDefault];
+                                                 launchOptions:launchOptions
+                                                  trackCrashes:trackCrashes
+                                         automaticPushTracking:automaticPushTracking
+                                       optOutTrackingByDefault:optOutTrackingByDefault;];
 
         // copy instances and add the new instance.  then reassign instances
         NSMutableDictionary *newInstances = [NSMutableDictionary dictionaryWithDictionary:instances];

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
+    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.minSdkVersion : 16
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
         versionCode 1
         versionName "1.0"
         ndk {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.mixpanel.android:mixpanel-android:5.6.0"
+    api "com.mixpanel.android:mixpanel-android:5.6.3"
 }

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -337,6 +337,21 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
+    public void union(final String name, final ReadableArray properties, final String apiToken, Promise promise) {
+        JSONArray obj = null;
+        try {
+            obj = RNMixpanelModule.reactToJSON(properties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        final MixpanelAPI instance = getInstance(apiToken);
+        synchronized(instance) {
+            instance.getPeople().union(name, obj);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
     public void reset(final String apiToken, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -377,6 +377,21 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
+    public void append(final String name, final ReadableArray properties, final String apiToken, Promise promise) {
+        JSONArray obj = null;
+        try {
+            obj = RNMixpanelModule.reactToJSON(properties);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        final MixpanelAPI instance = getInstance(apiToken);
+        synchronized(instance) {
+            instance.getPeople().append(name, obj);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
     public void reset(final String apiToken, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -291,6 +291,18 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
         promise.resolve(null);
     }
 
+    // Android only
+    @ReactMethod
+    public void getPushRegistrationId(final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        if (instance == null) {
+            promise.reject(new Throwable("no mixpanel instance available."));
+            return;
+        }
+        synchronized(instance) {
+            promise.resolve(instance.getPeople().getPushRegistrationId());
+        }
+    }
 
     // Android only
     @ReactMethod

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -135,7 +135,7 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void sharedInstanceWithToken(final String token, Promise promise) {
+    public void sharedInstanceWithToken(final String token, final Boolean optOutTracking, Promise promise) {
         synchronized (this) {
             // an instance can pre-exist when reloading javascript
             if (instances != null && instances.containsKey(token)) {
@@ -147,7 +147,11 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
                 promise.reject(new Throwable("no React application context"));
                 return;
             }
-            final MixpanelAPI instance = MixpanelAPI.getInstance(reactApplicationContext, token);
+
+            final MixpanelAPI instance = MixpanelAPI.getInstance(reactApplicationContext,
+                                                                 token,
+                                                                 optOutTracking);
+
             Map<String, MixpanelAPI> newInstances = new HashMap<>();
             if (instances != null) {
                 newInstances.putAll(instances);
@@ -438,9 +442,39 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     @ReactMethod
     public void showNotificationIfAvailable(final String apiToken, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
+        if (instance == null) {
+            promise.reject(new Throwable("no mixpanel instance available."));
+            return;
+        }
         synchronized(instance) {
             instance.getPeople().showNotificationIfAvailable(this.getCurrentActivity());
         }
         promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void optOutTracking(final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        if (instance == null) {
+            promise.reject(new Throwable("no mixpanel instance available."));
+            return;
+        }
+        synchronized(instance) {
+            instance.optOutTracking();
+            promise.resolve(null);
+        }
+    }
+
+    @ReactMethod
+    public void optInTracking(final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        if (instance == null) {
+            promise.reject(new Throwable("no mixpanel instance available."));
+            return;
+        }
+        synchronized(instance) {
+            instance.optInTracking();
+            promise.resolve(null);
+        }
     }
 }

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -434,4 +434,13 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
             promise.resolve(instance.getDistinctId());
         }
     }
+
+    @ReactMethod
+    public void showNotificationIfAvailable(final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        synchronized(instance) {
+            instance.getPeople().showNotificationIfAvailable(this.getCurrentActivity());
+        }
+        promise.resolve(null);
+    }
 }

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -304,10 +304,14 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
 
     // Android only
     @ReactMethod
-    public void clearPushRegistrationId(final String apiToken, Promise promise) {
+    public void clearPushRegistrationId(final String token, final String apiToken, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {
-            instance.getPeople().clearPushRegistrationId();
+            if (token != null) {
+                instance.getPeople().clearPushRegistrationId(token);
+            } else {
+                instance.getPeople().clearPushRegistrationId();
+            }
         }
         promise.resolve(null);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,9 @@ declare module 'react-native-mixpanel' {
     getPushRegistrationId(): Promise<string>
 
     // iOS only
+    removePushDeviceToken(pushDeviceToken: string): Promise<void>
+    removeAllPushDeviceTokens(): Promise<void>
+    addPushDeviceToken(token: string): Promise<void>
   }
 
   interface MixpanelAPI {

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,12 +58,13 @@ declare module 'react-native-mixpanel' {
     increment(property: string, by: number): void;
     union(name: string, properties: any[]): void;
     addPushDeviceToken(token: string): void;
+    clearSuperProperties(): void;
   
     // android only
     setPushRegistrationId(token: string): void;
   
     // android only
-    clearPushRegistrationId(): void;
+    clearPushRegistrationId(token?: string): void;
 
     reset(): void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ declare module 'react-native-mixpanel' {
     // android only
     setPushRegistrationId(token: string): void;
     clearPushRegistrationId(token?: string): void;
+    getPushRegistrationId(): Promise<string>;
 
     // iOS only
     addPushDeviceToken(token: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-mixpanel' {
   export class MixpanelInstance {
-    constructor(apiToken?: string)
+    constructor(apiToken?: string, optOutTrackingDefault?: boolean)
 
     initialize(): Promise<void>
     getDistinctId(): Promise<string>
@@ -24,6 +24,8 @@ declare module 'react-native-mixpanel' {
     clearSuperProperties(): Promise<void>
     reset(): Promise<void>
     showInAppMessageIfAvailable(): Promise<void>
+    optInTracking(): Promise<void>
+    optOutTracking(): Promise<void>
 
     // android only
     setPushRegistrationId(token: string): Promise<void>
@@ -37,7 +39,7 @@ declare module 'react-native-mixpanel' {
   }
 
   interface MixpanelAPI {
-    sharedInstanceWithToken(apiToken: string): Promise<void>;
+    sharedInstanceWithToken(apiToken: string, optOutTrackingDefault?: boolean): Promise<void>;
     getDistinctId(callback: (id?: string) => void): void;
     getSuperProperty(propertyName: string, callback: (value: any) => void): void;
     track(event: string): void;
@@ -60,6 +62,8 @@ declare module 'react-native-mixpanel' {
     clearSuperProperties(): void;
     reset(): void;
     showInAppMessageIfAvailable(): void;
+    optInTracking(): void
+    optOutTracking(): void
 
     // android only
     setPushRegistrationId(token: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ declare module 'react-native-mixpanel' {
     trackChargeWithProperties(charge: number, properties: Object): Promise<void>
     increment(property: string, by: number): Promise<void>
     union(name: string, properties: any[]): Promise<void>
-    removePushDeviceToken(deviceToken: Object): Promise<void>
+    removePushDeviceToken(pushDeviceToken: string): Promise<void>
     removeAllPushDeviceTokens(): Promise<void>
     addPushDeviceToken(token: string): Promise<void>
     clearSuperProperties(): Promise<void>
@@ -51,7 +51,7 @@ declare module 'react-native-mixpanel' {
     initPushHandling(token: string): void;
     set(properties: Object): void;
     setOnce(properties: Object): void;
-    removePushDeviceToken(deviceToken: Object): void;
+    removePushDeviceToken(pushDeviceToken: string): void;
     removeAllPushDeviceTokens(): void;
     trackCharge(charge: number): void;
     trackChargeWithProperties(charge: number, properties: Object): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare module 'react-native-mixpanel' {
     trackChargeWithProperties(charge: number, properties: Object): Promise<void>
     increment(property: string, by: number): Promise<void>
     union(name: string, properties: any[]): Promise<void>
+    append(name: string, properties: any[]): Promise<void>
     clearSuperProperties(): Promise<void>
     reset(): Promise<void>
 
@@ -54,6 +55,7 @@ declare module 'react-native-mixpanel' {
     trackChargeWithProperties(charge: number, properties: Object): void;
     increment(property: string, by: number): void;
     union(name: string, properties: any[]): void;
+    append(name: string, properties: any[]): void;
     clearSuperProperties(): void;
     reset(): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare module 'react-native-mixpanel' {
     removePushDeviceToken(deviceToken: Object): Promise<void>
     removeAllPushDeviceTokens(): Promise<void>
     addPushDeviceToken(token: string): Promise<void>
+    clearSuperProperties(): Promise<void>
 
     // android only
     setPushRegistrationId(token: string): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,8 @@ declare module 'react-native-mixpanel' {
     setPushRegistrationId(token: string): Promise<void>
   
     // android only
-    clearPushRegistrationId(): Promise<void>
+    clearPushRegistrationId(token?: string): Promise<void>
+    
 
     reset(): Promise<void>
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,13 +3,13 @@ declare module 'react-native-mixpanel' {
     constructor(apiToken?: string)
 
     initialize(): Promise<void>
-    getDistinctId(): Promise<string>  
+    getDistinctId(): Promise<string>
     getSuperProperty(propertyName: string): Promise<any>
     track(event: string, properties?: Object): Promise<void>
     flush(): Promise<void>
     disableIpAddressGeolocalization(): Promise<void>
     alias(alias: string): Promise<void>
-    identify(userId: string): Promise<void>  
+    identify(userId: string): Promise<void>
     timeEvent(event: string): Promise<void>
     registerSuperProperties(properties: Object): Promise<void>
     registerSuperPropertiesOnce(properties: Object): Promise<void>
@@ -56,11 +56,11 @@ declare module 'react-native-mixpanel' {
     union(name: string, properties: any[]): void;
     clearSuperProperties(): void;
     reset(): void;
-  
+
     // android only
     setPushRegistrationId(token: string): void;
     clearPushRegistrationId(token?: string): void;
-    getPushRegistrationId(): Promise<string>;
+    getPushRegistrationId(callback: (token?: string) => void): void;
 
     // iOS only
     addPushDeviceToken(token: string): void;
@@ -70,5 +70,5 @@ declare module 'react-native-mixpanel' {
 
   const mixpanelApi: MixpanelAPI;
   export default mixpanelApi;
-  
+
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,19 +20,15 @@ declare module 'react-native-mixpanel' {
     trackChargeWithProperties(charge: number, properties: Object): Promise<void>
     increment(property: string, by: number): Promise<void>
     union(name: string, properties: any[]): Promise<void>
-    removePushDeviceToken(pushDeviceToken: string): Promise<void>
-    removeAllPushDeviceTokens(): Promise<void>
-    addPushDeviceToken(token: string): Promise<void>
     clearSuperProperties(): Promise<void>
+    reset(): Promise<void>
 
     // android only
     setPushRegistrationId(token: string): Promise<void>
-  
-    // android only
     clearPushRegistrationId(token?: string): Promise<void>
-    
+    getPushRegistrationId(): Promise<string>
 
-    reset(): Promise<void>
+    // iOS only
   }
 
   interface MixpanelAPI {
@@ -51,22 +47,21 @@ declare module 'react-native-mixpanel' {
     initPushHandling(token: string): void;
     set(properties: Object): void;
     setOnce(properties: Object): void;
-    removePushDeviceToken(pushDeviceToken: string): void;
-    removeAllPushDeviceTokens(): void;
     trackCharge(charge: number): void;
     trackChargeWithProperties(charge: number, properties: Object): void;
     increment(property: string, by: number): void;
     union(name: string, properties: any[]): void;
-    addPushDeviceToken(token: string): void;
     clearSuperProperties(): void;
+    reset(): void;
   
     // android only
     setPushRegistrationId(token: string): void;
-  
-    // android only
     clearPushRegistrationId(token?: string): void;
 
-    reset(): void;
+    // iOS only
+    addPushDeviceToken(token: string): void;
+    removePushDeviceToken(pushDeviceToken: string): void;
+    removeAllPushDeviceTokens(): void;
   }
 
   const mixpanelApi: MixpanelAPI;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-mixpanel' {
   export class MixpanelInstance {
-    constructor(apiToken?: string, optOutTrackingDefault?: boolean)
+    constructor(apiToken?: string, optOutTrackingDefault?: boolean, trackCrashes?: boolean, automaticPushTracking?: boolean, launchOptions?: Object)
 
     initialize(): Promise<void>
     getDistinctId(): Promise<string>
@@ -39,7 +39,7 @@ declare module 'react-native-mixpanel' {
   }
 
   interface MixpanelAPI {
-    sharedInstanceWithToken(apiToken: string, optOutTrackingDefault?: boolean): Promise<void>;
+    sharedInstanceWithToken(apiToken: string, optOutTrackingDefault?: boolean, trackCrashes?: boolean, automaticPushTracking?: boolean, launchOptions?: Object): Promise<void>;
     getDistinctId(callback: (id?: string) => void): void;
     getSuperProperty(propertyName: string, callback: (value: any) => void): void;
     track(event: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ declare module 'react-native-mixpanel' {
     append(name: string, properties: any[]): Promise<void>
     clearSuperProperties(): Promise<void>
     reset(): Promise<void>
+    showInAppMessageIfAvailable(): Promise<void>
 
     // android only
     setPushRegistrationId(token: string): Promise<void>
@@ -58,6 +59,7 @@ declare module 'react-native-mixpanel' {
     append(name: string, properties: any[]): void;
     clearSuperProperties(): void;
     reset(): void;
+    showInAppMessageIfAvailable(): void;
 
     // android only
     setPushRegistrationId(token: string): void;

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export class MixpanelInstance {
   */
  getPushRegistrationId(): Promise<string> {
     if (!this.initialized) {
-      return Promise.reject(new Error(uninitializedError('getDistinctId')))
+      return Promise.reject(new Error(uninitializedError('getPushRegistrationId')))
     }
     if (!RNMixpanel.getPushRegistrationId) throw new Error('No native implementation for getPushRegistrationId.  This is Android only.')
     return RNMixpanel.getPushRegistrationId(this.apiToken)
@@ -60,7 +60,7 @@ export class MixpanelInstance {
   */
   getSuperProperty(propertyName: string): Promise<mixed> {
     if (!this.initialized) {
-      return Promise.reject(new Error(uninitializedError('getDistinctId')))
+      return Promise.reject(new Error(uninitializedError('getSuperProperty')))
     }
     return RNMixpanel.getSuperProperty(propertyName, this.apiToken)
   }
@@ -240,15 +240,15 @@ export default {
   /*
   Retrieves current Firebase Cloud Messaging token.
   */
-  getPushRegistrationId(callback: (id: ?string) => void) {
+  getPushRegistrationId(callback: (token: ?string) => void) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.getPushRegistrationId()
-      .then((id: string) => {
-        callback(id)
+      .then((token: string) => {
+        callback(token)
       })
       .catch((err) => {
-        console.error('Error in mixpanel getDistinctId', err)
+        console.error('Error in mixpanel getPushRegistrationId', err)
         callback(null)
       })
   },

--- a/index.js
+++ b/index.js
@@ -71,6 +71,11 @@ export class MixpanelInstance {
     return RNMixpanel.flush(this.apiToken)
   }
 
+  disableIpAddressGeolocalization(): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('disableIpAddressGeolocalization'))
+    return RNMixpanel.disableIpAddressGeolocalization(this.apiToken)
+  }
+
   alias(alias: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('createAlias'))
 
@@ -239,6 +244,12 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.flush()
+  },
+
+  disableIpAddressGeolocalization() {
+      if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+      defaultInstance.disableIpAddressGeolocalization()
   },
 
   createAlias(alias: string) {

--- a/index.js
+++ b/index.js
@@ -45,6 +45,16 @@ export class MixpanelInstance {
   }
 
   /*
+  Retrieves current Firebase Cloud Messaging token.
+  */
+ getPushRegistrationId(): Promise<string> {
+    if (!this.initialized) {
+      return Promise.reject(new Error(uninitializedError('getDistinctId')))
+    }
+    return RNMixpanel.getDistinctId(this.apiToken)
+  }
+
+  /*
   Gets the given super property.  Returns a promise that resolves to the value.
   */
   getSuperProperty(propertyName: string): Promise<mixed> {
@@ -217,6 +227,22 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.getDistinctId()
+      .then((id: string) => {
+        callback(id)
+      })
+      .catch((err) => {
+        console.error('Error in mixpanel getDistinctId', err)
+        callback(null)
+      })
+  },
+
+  /*
+  Retrieves current Firebase Cloud Messaging token.
+  */
+  getPushRegistrationId(callback: (id: ?string) => void) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.getPushRegistrationId()
       .then((id: string) => {
         callback(id)
       })

--- a/index.js
+++ b/index.js
@@ -209,6 +209,16 @@ export class MixpanelInstance {
 
     return RNMixpanel.reset(this.apiToken)
   }
+
+  showInAppMessageIfAvailable(): Promise<void> {
+    if (!this.initialized) throw uninitializedError('showNotificationIfAvailable')
+
+    if (Platform.OS === "android") {
+        return RNMixpanel.showNotificationIfAvailable(this.apiToken)
+    } else {
+        return RNMixpanel.showNotification(this.apiToken)
+    }
+  }
 }
 
 /*
@@ -416,6 +426,11 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.reset()
+  },
+
+  showInAppMessageIfAvailable() {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+    defaultInstance.showInAppMessageIfAvailable(token)
   },
 
 }

--- a/index.js
+++ b/index.js
@@ -164,6 +164,12 @@ export class MixpanelInstance {
     return RNMixpanel.union(name, properties, this.apiToken)
   }
 
+  append(name: string, properties: any[]): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('append'))
+
+    return RNMixpanel.append(name, properties, this.apiToken)
+  }
+
   removePushDeviceToken(pushDeviceToken: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('removePushDeviceToken'))
 
@@ -378,6 +384,12 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.union(name, properties)
+  },
+
+  append(name: string, properties: any[]) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.append(name, properties)
   },
 
   addPushDeviceToken(token: string) {

--- a/index.js
+++ b/index.js
@@ -153,10 +153,10 @@ export class MixpanelInstance {
     return RNMixpanel.union(name, properties, this.apiToken)
   }
 
-  removePushDeviceToken(deviceToken: Object): Promise<void> {
+  removePushDeviceToken(pushDeviceToken: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('removePushDeviceToken'))
 
-    return RNMixpanel.removePushDeviceToken(deviceToken, this.apiToken)
+    return RNMixpanel.removePushDeviceToken(pushDeviceToken, this.apiToken)
   }
 
   removeAllPushDeviceTokens(): Promise<void> {
@@ -317,10 +317,10 @@ export default {
     defaultInstance.setOnce(properties)
   },
 
-  removePushDeviceToken(deviceToken: Object) {
+  removePushDeviceToken(pushDeviceToken: string) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
-    defaultInstance.removePushDeviceToken(deviceToken)
+    defaultInstance.removePushDeviceToken(pushDeviceToken)
   },
 
   removeAllPushDeviceTokens() {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // @flow
 'use strict'
-import { NativeModules } from 'react-native'
+import { NativeModules, Platform } from 'react-native'
 const { RNMixpanel } = NativeModules
 
 /*

--- a/index.js
+++ b/index.js
@@ -180,11 +180,11 @@ export class MixpanelInstance {
   }
 
   // android only
-  clearPushRegistrationId(): Promise<void> {
+  clearPushRegistrationId(token?: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('clearPushRegistrationId'))
 
     if (!RNMixpanel.clearPushRegistrationId) throw new Error('No native implementation for setPusclearPushRegistrationIdhRegistrationId.  This is Android only.')
-    return RNMixpanel.clearPushRegistrationId()
+    return RNMixpanel.clearPushRegistrationId(token, this.apiToken)
   }
 
   reset(): Promise<void> {
@@ -367,10 +367,10 @@ export default {
   },
 
   // android only
-  clearPushRegistrationId() {
+  clearPushRegistrationId(token?: string) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
-    defaultInstance.clearPushRegistrationId()
+    defaultInstance.clearPushRegistrationId(token)
   },
 
   reset() {

--- a/index.js
+++ b/index.js
@@ -142,6 +142,12 @@ export class MixpanelInstance {
     return RNMixpanel.increment(property, by, this.apiToken)
   }
 
+  union(name: string, properties: any[]): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('union'))
+
+    return RNMixpanel.union(name, properties, this.apiToken)
+  }
+
   removePushDeviceToken(deviceToken: Object): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('removePushDeviceToken'))
 
@@ -328,6 +334,12 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.increment(property, by)
+  },
+
+  union(name: string, properties: any[]) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.union(name, properties)
   },
 
   addPushDeviceToken(token: string) {

--- a/index.js
+++ b/index.js
@@ -18,11 +18,17 @@ However since React Native makes no guarantees about whether native methods are 
 export class MixpanelInstance {
   apiToken: ?string
   optOutTrackingDefault: boolean
+  trackCrashes: boolean
+  automaticPushTracking: boolean
+  launchOptions: object
   initialized: boolean
 
-  constructor(apiToken: ?string, optOutTrackingDefault: ?boolean = false) {
+  constructor(apiToken: ?string, optOutTrackingDefault: ?boolean = false, trackCrashes: ?boolean = true, automaticPushTracking: ?boolean = true, launchOptions: ?Object = null) {
     this.apiToken = apiToken
     this.optOutTrackingDefault = optOutTrackingDefault
+    this.trackCrashes = trackCrashes
+    this.automaticPushTracking = automaticPushTracking
+    this.launchOptions = launchOptions
     this.initialized = false
   }
 
@@ -30,10 +36,17 @@ export class MixpanelInstance {
   Initializes the instance in native land.  Returns a promise that resolves when the instance has been created and is ready for use.
   */
   initialize(): Promise<void> {
-    return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.optOutTrackingDefault)
+    if (Platform.OS === 'ios'){
+      return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.optOutTrackingDefault, this.trackCrashes, this.automaticPushTracking, this.launchOptions)
       .then(() => {
         this.initialized = true
       })
+    } else {
+      return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.optOutTrackingDefault)
+      .then(() => {
+        this.initialized = true
+      })
+    }
   }
 
   /*
@@ -243,7 +256,7 @@ mixpanel.track('my event')
 */
 export default {
 
-  sharedInstanceWithToken(apiToken: string, optOutTrackingDefault: ?boolean = false): Promise<void> {
+  sharedInstanceWithToken(apiToken: string, optOutTrackingDefault: ?boolean = false, trackCrashes: ?boolean = true, automaticPushTracking: ?boolean = true, launchOptions: ?Object = null): Promise<void> {
     const instance = new MixpanelInstance(apiToken, optOutTrackingDefault)
     if (!defaultInstance) defaultInstance = instance
     return instance.initialize()

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ export class MixpanelInstance {
     if (!this.initialized) {
       return Promise.reject(new Error(uninitializedError('getDistinctId')))
     }
-    return RNMixpanel.getDistinctId(this.apiToken)
+    if (!RNMixpanel.getPushRegistrationId) throw new Error('No native implementation for getPushRegistrationId.  This is Android only.')
+    return RNMixpanel.getPushRegistrationId(this.apiToken)
   }
 
   /*

--- a/index.js
+++ b/index.js
@@ -17,10 +17,12 @@ However since React Native makes no guarantees about whether native methods are 
 */
 export class MixpanelInstance {
   apiToken: ?string
+  optOutTrackingDefault: boolean
   initialized: boolean
 
-  constructor(apiToken: ?string) {
+  constructor(apiToken: ?string, optOutTrackingDefault: ?boolean = false) {
     this.apiToken = apiToken
+    this.optOutTrackingDefault = optOutTrackingDefault
     this.initialized = false
   }
 
@@ -28,7 +30,7 @@ export class MixpanelInstance {
   Initializes the instance in native land.  Returns a promise that resolves when the instance has been created and is ready for use.
   */
   initialize(): Promise<void> {
-    return RNMixpanel.sharedInstanceWithToken(this.apiToken)
+    return RNMixpanel.sharedInstanceWithToken(this.apiToken, this.optOutTrackingDefault)
       .then(() => {
         this.initialized = true
       })
@@ -219,6 +221,16 @@ export class MixpanelInstance {
         return RNMixpanel.showNotification(this.apiToken)
     }
   }
+
+  optInTracking(): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('optInTracking'))
+    return RNMixpanel.optInTracking(this.apiToken)
+  }
+
+  optOutTracking(): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('optOutTracking'))
+    return RNMixpanel.optOutTracking(this.apiToken)
+  }
 }
 
 /*
@@ -231,8 +243,8 @@ mixpanel.track('my event')
 */
 export default {
 
-  sharedInstanceWithToken(apiToken: string): Promise<void> {
-    const instance = new MixpanelInstance(apiToken)
+  sharedInstanceWithToken(apiToken: string, optOutTrackingDefault: ?boolean = false): Promise<void> {
+    const instance = new MixpanelInstance(apiToken, optOutTrackingDefault)
     if (!defaultInstance) defaultInstance = instance
     return instance.initialize()
   },
@@ -433,4 +445,15 @@ export default {
     defaultInstance.showInAppMessageIfAvailable(token)
   },
 
+  optInTracking() {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.optInTracking()
+  },
+
+  optOutTracking() {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.optOutTracking()
+  },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -1,14 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
 Pod::Spec.new do |s|
-  s.name             = "react-native-mixpanel"
-  s.version          = "0.0.6"
-  s.summary          = "React Native wrapper for Mixpanel tracking"
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
   s.requires_arc = true
-  s.author       = { 'Davide Scalzo' => 'davidescalzo@gmail.com' }
-  s.license      = 'MIT'
-  s.homepage     = 'n/a'
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
-  s.platform     = :ios, "7.0"
-  s.dependency 'Mixpanel', '~> 3.4.7'
+  s.platform     = :ios, "8.0"
+  s.dependency 'Mixpanel', '~> 3.5.0'
   s.dependency 'React'
 end

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "7.0"
-  s.dependency 'Mixpanel', '~> 3.4.4'
+  s.dependency 'Mixpanel', '~> 3.4.5'
   s.dependency 'React'
 end

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "7.0"
-  s.dependency 'Mixpanel', '~> 3.4.5'
+  s.dependency 'Mixpanel', '~> 3.4.7'
   s.dependency 'React'
 end

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "8.0"
+  s.tvos.deployment_target = '10.0'
   s.dependency 'Mixpanel', '~> 3.5.0'
   s.dependency 'React'
 end


### PR DESCRIPTION
[Android] Allow to retrieve current Firebase Cloud Messaging token.
[Android] Add support for clearing a single registration id on Android
[iOS] Pass deviceToken as string to `removePushDeviceToken`  as more convenient way
[General] Update Readme.md
[General] Update index.d.ts
[General] Update npm package version