### PR TITLE
fix(push): Crash clearPushRegistrationId

### DIFF
--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -304,10 +304,14 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
 
     // Android only
     @ReactMethod
-    public void clearPushRegistrationId(final String apiToken, Promise promise) {
+    public void clearPushRegistrationId(final String apiToken, String registrationId, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {
-            instance.getPeople().clearPushRegistrationId();
+            if (registrationId == null) {
+                instance.getPeople().clearPushRegistrationId();
+            } else {
+                instance.getPeople().clearPushRegistrationId(registrationId);
+            }
         }
         promise.resolve(null);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare module 'react-native-mixpanel' {
     setPushRegistrationId(token: string): Promise<void>
   
     // android only
-    clearPushRegistrationId(): Promise<void>
+    clearPushRegistrationId(token?: string): Promise<void>
 
     reset(): Promise<void>
   }
@@ -61,7 +61,7 @@ declare module 'react-native-mixpanel' {
     setPushRegistrationId(token: string): void;
   
     // android only
-    clearPushRegistrationId(): void;
+    clearPushRegistrationId(token?: string): void;
 
     reset(): void;
   }

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ export class MixpanelInstance {
     if (!this.initialized) throw new Error(uninitializedError('clearPushRegistrationId'))
 
     if (!RNMixpanel.clearPushRegistrationId) throw new Error('No native implementation for setPusclearPushRegistrationIdhRegistrationId.  This is Android only.')
-    return RNMixpanel.clearPushRegistrationId(this.apiToken, token)
+    return RNMixpanel.clearPushRegistrationId(this.apiToken, token || null)
   }
 
   reset(): Promise<void> {
@@ -367,10 +367,10 @@ export default {
   },
 
   // android only
-  clearPushRegistrationId() {
+  clearPushRegistrationId(token?: string) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
-    defaultInstance.clearPushRegistrationId()
+    defaultInstance.clearPushRegistrationId(token || null)
   },
 
   reset() {

--- a/index.js
+++ b/index.js
@@ -180,11 +180,11 @@ export class MixpanelInstance {
   }
 
   // android only
-  clearPushRegistrationId(): Promise<void> {
+  clearPushRegistrationId(token?: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('clearPushRegistrationId'))
 
     if (!RNMixpanel.clearPushRegistrationId) throw new Error('No native implementation for setPusclearPushRegistrationIdhRegistrationId.  This is Android only.')
-    return RNMixpanel.clearPushRegistrationId()
+    return RNMixpanel.clearPushRegistrationId(this.apiToken, token)
   }
 
   reset(): Promise<void> {


### PR DESCRIPTION
This should fix crash caused by incorrect `clearPushRegistrationId` interface. Also update the typescript definition.

Ref: https://github.com/davodesign84/react-native-mixpanel/issues/134