### PR TITLE
Add methods add, set for Group Analytics. Only single values supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ Mixpanel.set({"$email": "elvis@email.com"});
 // Set People Properties Once (warning: if no mixpanel profile has been assigned to the current user when this method is called, it will automatically create a new mixpanel profile and the user will no longer be anonymous in Mixpanel)
 Mixpanel.setOnce({"$email": "elvis@email.com", "Created": new Date().toISOString()});
 
+// Add a new Group for this user.
+// @param Group key
+// @param A valid Mixpanel property type
+Mixpanel.setGroup('company', 'mixpanel');
+
+// Register the current user into one Group. The Group must be added before setting
+// @param Group key
+// @param a singular group ID
+Mixpanel.setGroup('company', 'mixpanel');
+
 // Timing Events
 // Sets the start time for an action, for example uploading an image
 Mixpanel.timeEvent("Image Upload");

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -143,6 +143,26 @@ RCT_EXPORT_METHOD(identify:(NSString *) uniqueId
     resolve(nil);
 }
 
+// add Group
+RCT_EXPORT_METHOD(addGroup:(NSString *)groupKey
+                  groupId:(NSString *)groupId
+                  apiToken:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[self getInstance:apiToken] addGroup:groupKey groupID:groupId];
+    resolve(nil);
+}
+
+// set Group
+RCT_EXPORT_METHOD(setGroup:(NSString *)groupKey
+                  groupId:(NSString *)groupId
+                  apiToken:(NSString *)apiToken
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [[self getInstance:apiToken] setGroup:groupKey groupID:groupId];
+    resolve(nil);
+}
+
 // Timing Events
 RCT_EXPORT_METHOD(timeEvent:(NSString *)event
                   apiToken:(NSString *)apiToken

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -211,6 +211,24 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
+    public void addGroup(final String groupKey, final String groupId, final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        synchronized(instance) {
+            instance.addGroup(groupKey, groupId);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void setGroup(final String groupKey, final String groupId, final String apiToken, Promise promise) {
+        final MixpanelAPI instance = getInstance(apiToken);
+        synchronized(instance) {
+            instance.setGroup(groupKey, groupId);
+        }
+        promise.resolve(null);
+    }
+
+    @ReactMethod
     public void timeEvent(final String event, final String apiToken, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,8 @@ declare module 'react-native-mixpanel' {
     disableIpAddressGeolocalization(): Promise<void>
     alias(alias: string, oldDistinctID?: string): Promise<void>
     identify(userId: string): Promise<void>
+    addGroup(groupKey: string, groupId: string): Promise<void>
+    setGroup(groupKey: string, groupId: string): Promise<void>
     timeEvent(event: string): Promise<void>
     registerSuperProperties(properties: Object): Promise<void>
     registerSuperPropertiesOnce(properties: Object): Promise<void>
@@ -48,6 +50,8 @@ declare module 'react-native-mixpanel' {
     disableIpAddressGeolocalization(): void;
     createAlias(alias: string, oldDistinctID?: string): void;
     identify(userId: string): void;
+    addGroup(groupKey: string, groupId: string): void;
+    setGroup(groupKey: string, groupId: string): void;
     timeEvent(event: string): void;
     registerSuperProperties(properties: Object): void;
     registerSuperPropertiesOnce(properties: Object): void;

--- a/index.js
+++ b/index.js
@@ -114,6 +114,18 @@ export class MixpanelInstance {
     return RNMixpanel.identify(userId, this.apiToken)
   }
 
+  addGroup(groupKey: string, groupId: string): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('addGroup'))
+
+    return RNMixpanel.addGroup(groupKey, groupId, this.apiToken)
+  }
+
+  setGroup(groupKey: string, groupId: string): Promise<void> {
+      if (!this.initialized) throw new Error(uninitializedError('setGroup'))
+
+      return RNMixpanel.setGroup(groupKey, groupId, this.apiToken)
+  }
+
   timeEvent(event: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('timeEvent'))
 
@@ -341,6 +353,18 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.identify(userId)
+  },
+
+  addGroup(groupKey: string, groupId: string) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.addGroup(groupKey, groupId)
+  },
+
+  setGroup(groupKey: string, groupId: string) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.setGroup(groupKey, groupId)
   },
 
   timeEvent(event: string) {


### PR DESCRIPTION
Closed #216 

Tested with this React Native code in Android/iOS simulators
```
      await this.mixpanel.addGroup('company', 'mixpanel');
```
```
      await this.mixpanel.setGroup('company', 'mixpanel');
```

Mixpanel admin screen
<img width="1143" alt="Mixpanel admin screen" src="https://user-images.githubusercontent.com/1093286/72763304-1dd83d80-3b98-11ea-8861-e4649509622d.png">
