### PR TITLE
Update react-native-mixpanel.podspec

### DIFF
--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "8.0"
   s.tvos.deployment_target = '10.0'
-  s.dependency 'Mixpanel', '~> 3.5.0'
+  s.dependency 'Mixpanel', '3.5.1'
   s.dependency 'React'
 end


### PR DESCRIPTION
`~> 3.5.0` optimistically results in `3.5.2` which [doesn't exist](https://github.com/davodesign84/react-native-mixpanel/issues/220)