### PR TITLE
Update due the version of Mixpanel on cocoapods

### DIFF
--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source_files = 'RNMixpanel/*'
   s.platform     = :ios, "8.0"
   s.tvos.deployment_target = '10.0'
-  s.dependency 'Mixpanel', '~> 3.5.0'
+  s.dependency 'Mixpanel', '~> 3.6.0'
   s.dependency 'React'
 end


### PR DESCRIPTION
The version available to pod install now are the 3.6.0 version, with the old 3.5.0, the package are failing on install ios depencendy.