### PR TITLE
Upgraded android mixpanel library to 5.8.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.mixpanel.android:mixpanel-android:5.6.8"
+    api "com.mixpanel.android:mixpanel-android:5.8.4"
 }

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -281,15 +281,6 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void initPushHandling (final String token, final String apiToken, Promise promise) {
-        final MixpanelAPI instance = getInstance(apiToken);
-        synchronized(instance) {
-            instance.getPeople().initPushHandling(token);
-        }
-        promise.resolve(null);
-    }
-
-    @ReactMethod
     public void set(final ReadableMap properties, final String apiToken, Promise promise) {
         JSONObject obj = null;
         try {


### PR DESCRIPTION
removed initPushHandling call from react native module
Followed the below mentioned steps
https://help.mixpanel.com/hc/en-us/articles/115004706906-Google-Cloud-Messaging-GCM-Migration-to-Firebase-Cloud-Messaging-FCM-