### PR TITLE
Fix `showInAppMessageIfAvailable`

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,7 +479,7 @@ export default {
 
   showInAppMessageIfAvailable() {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
-    defaultInstance.showInAppMessageIfAvailable(token)
+    defaultInstance.showInAppMessageIfAvailable()
   },
 
   optInTracking() {


### PR DESCRIPTION
Fix `showInAppMessageIfAvailable` : No token parameter required, but still sending unknown variable.

Fixes #256 