### PR TITLE
Update Mixpanel Android SDK to 5.7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.mixpanel.android:mixpanel-android:5.6.8"
+    api "com.mixpanel.android:mixpanel-android:5.7.0"
 }


### PR DESCRIPTION
Updates the Mixpanel Android SDK to 5.7, which includes support for rich push notifications. Mixpanel Android is currently on 5.8.5 but I opted to just bump to 5.7 in this PR and test 5.8.5 more thoroughly later.

https://github.com/mixpanel/mixpanel-android/releases/tag/v5.7.0