### PR TITLE
Upgrade Mixpanel Android SDK to 5.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.4
+
+- [Android] Update Mixpanel Android SDK to 5.8.5
+
 # 1.1.14
 
 - [Android] Add check against potential NPE 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.mixpanel.android:mixpanel-android:5.6.8"
+    api "com.mixpanel.android:mixpanel-android:5.8.5"
 }

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -281,11 +281,10 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void initPushHandling (final String token, final String apiToken, Promise promise) {
-        final MixpanelAPI instance = getInstance(apiToken);
-        synchronized(instance) {
-            instance.getPeople().initPushHandling(token);
-        }
+    public void initPushHandling(final String token, final String apiToken, Promise promise) {
+        // MixpanelAPI.initPushHandling is deprecated.
+        // Mixpanel now uses Firebase Cloud Messaging.
+        // initPushHandling will be removed in a future version.
         promise.resolve(null);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This upgrades Mixpanel Android from 5.6.8 to 5.8.5 which includes a number of fixes and push notifications enhancements.

https://github.com/mixpanel/mixpanel-android/releases