### PR TITLE
fix disabling automatic push tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ mixpanel.track('my event')
 export default {
 
   sharedInstanceWithToken(apiToken: string, optOutTrackingDefault: ?boolean = false, trackCrashes: ?boolean = true, automaticPushTracking: ?boolean = true, launchOptions: ?Object = null): Promise<void> {
-    const instance = new MixpanelInstance(apiToken, optOutTrackingDefault)
+    const instance = new MixpanelInstance(apiToken, optOutTrackingDefault, trackCrashes, automaticPushTracking, launchOptions)
     if (!defaultInstance) defaultInstance = instance
     return instance.initialize()
   },


### PR DESCRIPTION
Hello,

Understand this lib is prob deprecated but I am still using it and we're using the mp messaging until it gets fully turned off. I wanted to disable swizzling and saw it was broken so decided to patch.

Seems the trackCrashes, automaticPushTracking and launchOptions aren't passed consistently from the react code to the native code.